### PR TITLE
Add overflowX hidden to carousel.tsx

### DIFF
--- a/components/common/Carousel/carousel.tsx
+++ b/components/common/Carousel/carousel.tsx
@@ -56,7 +56,13 @@ export const Carousel: FC<CarouselProps> = (props: CarouselProps) => {
   return (
     <>
       <TabNavMenu value={currentCard} turner={turn}/>
-      <div className="relative p-2 pt-0 lg:p-10" style={{ height: '90%' }}>
+      <div
+        className="relative p-2 pt-0 lg:p-10"
+        style={{
+          height: '90%',
+          overflowX: 'hidden',
+        }}
+      >
         <AnimatePresence>
           <div className="h-full">
             <motion.div


### PR DESCRIPTION
Prevent scroll with overflowX: 'hidden' on carousel.tsx's outer div

## Overview

List the GitHub issues containing the issues relevant to this pull request.

Resolves #33

Prevents the animation between pages in the carousel component from momentarily causing a scrollbar to appear at the bottom of the screen.

## What Changed

Added `overflowX: 'hidden'` to the child div in carousel.tsx