### PR TITLE
Link preview typo fix

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,14 +6,14 @@ function Document() {
       <Head prefix="og: http://ogp.me/ns#">
         <meta
           name="description"
-          content="UTD Trends a data visualization tool built to help students view historical course and section data."
+          content="A data visualization tool built to help students view historical course and section data."
         />
         <meta name="theme-color" content="#7486ce" />
 
         <meta property="og:title" content="UTD Trends" />
         <meta
           property="og:description"
-          content="UTD Trends a data visualization tool built to help students view historical course and section data."
+          content="A data visualization tool built to help students view historical course and section data."
         />
         <meta property="og:type" content="website" />
         <meta


### PR DESCRIPTION
There was a typo and some unnecessary repetitiveness in the sentence for the link preview that displays on things like search results and in messaging apps that preview links.