### PR TITLE
Revert horizontal bar graph direction change

### DIFF
--- a/components/graph/HorizontalBarGraph/HorizontalBarGraph.tsx
+++ b/components/graph/HorizontalBarGraph/HorizontalBarGraph.tsx
@@ -20,7 +20,7 @@ export function HorizontalBarGraph(props: GraphProps) {
     },
     plotOptions: {
       bar: {
-        horizontal: false,
+        horizontal: true,
       },
     },
     dataLabels: {

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -452,7 +452,7 @@ export const Dashboard: NextPage = () => {
           <div className="grid grid-cols-1 md:grid-cols-2">
             <Card className="h-96 p-4 m-4">
               <GraphChoice
-                form="Bar"
+                form="Vertical"
                 title="GPA Averages"
                 xaxisLabels={['Average']}
                 series={averageDat}
@@ -460,7 +460,7 @@ export const Dashboard: NextPage = () => {
             </Card>
             <Card className="h-96 p-4 m-4">
               <GraphChoice
-                form="Bar"
+                form="Vertical"
                 title="GPA Standard Deviations"
                 xaxisLabels={['Standard Deviation']}
                 series={stdevDat}


### PR DESCRIPTION
The horizontal bar graph was erroneously changed to vertical recently, this reverts that change. It however, maintains the GPA graphs in a vertical state as they have at most 3 bars, not 42.
