### PR TITLE
Bug fix: Horizontal bar label formatter

### DIFF
--- a/components/graph/HorizontalBarGraph/HorizontalBarGraph.tsx
+++ b/components/graph/HorizontalBarGraph/HorizontalBarGraph.tsx
@@ -28,8 +28,6 @@ export function HorizontalBarGraph(props: GraphProps) {
     },
     xaxis: {
       categories: props.xaxisLabels,
-    },
-    yaxis: {
       labels: {
         formatter: props.yaxisFormatter,
       },

--- a/components/graph/HorizontalBarGraph/HorizontalBarGraph.tsx
+++ b/components/graph/HorizontalBarGraph/HorizontalBarGraph.tsx
@@ -11,6 +11,13 @@ import React from 'react';
  * @returns horizontal bar graph
  */
 export function HorizontalBarGraph(props: GraphProps) {
+  function xaxisFormatter(value: string) {
+    if (typeof props.yaxisFormatter === 'undefined') {
+      return value;
+    }
+    return props.yaxisFormatter(Number(value));
+  }
+  
   const options: ApexOptions = {
     chart: {
       id: 'line-chart',
@@ -29,7 +36,7 @@ export function HorizontalBarGraph(props: GraphProps) {
     xaxis: {
       categories: props.xaxisLabels,
       labels: {
-        formatter: props.yaxisFormatter,
+        formatter: xaxisFormatter,
       },
     },
     colors: ['#eb5757', '#2d9cdb', '#499F68'],


### PR DESCRIPTION
## Overview

Fix bug preventing bar graph render on mobile.

Since the xaxis and yaxis flip, the yaxisFormatter function was throwing errors trying to format the wrong axis. This moves it to the over axis and accounts for some differences in the function definitions defined by ApexCharts.
