### PR TITLE
Remove clear on blur

### DIFF
--- a/components/common/SearchBar/searchBar.tsx
+++ b/components/common/SearchBar/searchBar.tsx
@@ -75,6 +75,7 @@ export const SearchBar = (props: SearchProps) => {
       <div className="text-primary w-full max-w-2xl h-fit flex flex-row items-start">
         <Autocomplete
           autoHighlight={true}
+          clearOnBlur={false}
           disabled={props.disabled}
           className="w-full h-12 bg-primary-light font-sans"
           open={open}

--- a/components/common/SplashPageSearchBar/splashPageSearchBar.tsx
+++ b/components/common/SplashPageSearchBar/splashPageSearchBar.tsx
@@ -61,6 +61,7 @@ export const SplashPageSearchBar = (props: SearchProps) => {
       <div className="text-primary m-auto w-11/12 -translate-y-1/4">
         <Autocomplete
           autoHighlight={true}
+          clearOnBlur={false}
           disabled={props.disabled}
           className="w-full h-12"
           getOptionLabel={(option) => searchQueryLabel(option)}


### PR DESCRIPTION
Saw this handy prop in the MUI API and always thought it was annoying that the search cleared when you deselect it.

https://mui.com/material-ui/api/autocomplete/#Autocomplete-prop-clearOnBlur