### PR TITLE
Slight autocomplete performance improvement

### DIFF
--- a/scripts/generateAutocompleteGraph.ts
+++ b/scripts/generateAutocompleteGraph.ts
@@ -23,6 +23,7 @@ fetch('https://catfact.ninja/fact', { method: 'GET' })
       allowSelfLoops: false,
     });
     let numNodes = 0; //allows a unique name for each node
+    let numEdges = 0;
     const root = graph.addNode(numNodes++, {
       c: '',
       visited: false,
@@ -58,14 +59,14 @@ fetch('https://catfact.ninja/fact', { method: 'GET' })
           newData.d = data;
         }
         const newNode = graph.addNode(numNodes++, newData);
-        graph.addEdge(node, newNode);
+        graph.addEdgeWithKey(numEdges++, node, newNode);
         return newNode;
       }
       const newNode = graph.addNode(numNodes++, {
         c: characters[0],
         visited: false,
       });
-      graph.addEdge(node, newNode);
+      graph.addEdgeWithKey(numEdges++, node, newNode);
       return addSearchQueryCharacter(newNode, characters.slice(1), data);
     }
 
@@ -83,7 +84,7 @@ fetch('https://catfact.ninja/fact', { method: 'GET' })
       while (nodes.length) {
         const nextParent = nodes.pop();
         if (!graph.hasEdge(nextParent, nodeFirstChar)) {
-          graph.addEdge(nextParent, nodeFirstChar);
+          graph.addEdgeWithKey(numEdges++, nextParent, nodeFirstChar);
         }
       }
       if (characters.length > 1) {
@@ -311,7 +312,7 @@ fetch('https://catfact.ninja/fact', { method: 'GET' })
             graph.forEachOutNeighbor(singleChild, (grandchild: string) => {
               graph.dropEdge(singleChild, grandchild);
               if (!graph.hasEdge(parent, grandchild) && parent !== grandchild) {
-                graph.addEdge(parent, grandchild);
+                graph.addEdgeWithKey(numEdges++, parent, grandchild);
               }
             });
             graph.dropNode(singleChild);


### PR DESCRIPTION
Slight improvement to autocomplete response time by reducing edge key size.
Also reduces the size of `data/autocomplete_graph.json` by about 1.5 Mb.

The main choke point, which is not addressed in this PR, is with `graph.import(autocompleteGraph as object);` in `pages\api\autocomplete.ts`. This line runs when the API is first accessed and when it hasn't been used in a while and Vercel has shut down the route. It takes approximately 500ms on my machine.