### PR TITLE
Autocomplete performance improvement

### DIFF
--- a/components/common/SearchBar/searchBar.tsx
+++ b/components/common/SearchBar/searchBar.tsx
@@ -74,6 +74,10 @@ export const SearchBar = (props: SearchProps) => {
     }
   }, [open, inputValue]);
 
+  useEffect(() => {
+    fetch('/api/autocomplete');
+  }, []);
+
   return (
     <>
       <div className="text-primary w-full max-w-2xl h-fit flex flex-row items-start">

--- a/components/common/SplashPageSearchBar/splashPageSearchBar.tsx
+++ b/components/common/SplashPageSearchBar/splashPageSearchBar.tsx
@@ -60,6 +60,10 @@ export const SplashPageSearchBar = (props: SearchProps) => {
     };
   }, [inputValue]);
 
+  useEffect(() => {
+    fetch('/api/autocomplete');
+  }, []);
+
   return (
     <>
       <div className="text-primary m-auto w-11/12 -translate-y-1/4">


### PR DESCRIPTION
The main slowness with the autocomplete system was waiting for Vercel to "spin up" the endpoint when it hadn't been used in a while. This change makes a call to the endpoint immediately on page load so it's running by the time you get to the search bar, hopefully.