### PR TITLE
Remove nodag stuff, causes confusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,9 @@
   "name": "UTD-Trends",
   "private": true,
   "scripts": {
-    "predev": "ts-node scripts/generateAutocompleteGraph.ts",
     "dev": "next dev",
-    "dev:nodag": "next dev",
-    "prebuild": "ts-node scripts/generateAutocompleteGraph.ts",
     "build": "next build",
-    "build:nodag": "next build",
+    "buildautocomplete": "ts-node scripts/generateAutocompleteGraph.ts",
     "start": "next start",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
We don't need to be building the autocomplete graph on every deployment rn so I removed the package scripts that do that.

Once there's an API endpoint to get the data needed for the autocomplete graph we can set vercel to do `npm run buildautocomplete && npm run build` on deployment.