### PR TITLE
Re add overall in search results

### DIFF
--- a/components/common/Compare/compare.tsx
+++ b/components/common/Compare/compare.tsx
@@ -54,7 +54,13 @@ const Compare = ({ courses, grades, rmp, removeFromCompare }: CompareProps) => {
           series={courses.map((course) => {
             const grade = grades[searchQueryLabel(course)];
             return {
-              name: searchQueryLabel(course),
+              name: searchQueryLabel(course) +
+                ((typeof course.profFirst === 'undefined' &&
+                  typeof course.profLast === 'undefined') ||
+                (typeof course.prefix === 'undefined' &&
+                  typeof course.number === 'undefined')
+                  ? ' (Overall)' //Indicates that this entry is an aggregate for the entire course/professor
+                  : ''),
               data:
                 grade.state === 'done'
                   ? convertNumbersToPercents(grade.data)

--- a/components/common/Compare/compare.tsx
+++ b/components/common/Compare/compare.tsx
@@ -54,7 +54,8 @@ const Compare = ({ courses, grades, rmp, removeFromCompare }: CompareProps) => {
           series={courses.map((course) => {
             const grade = grades[searchQueryLabel(course)];
             return {
-              name: searchQueryLabel(course) +
+              name:
+                searchQueryLabel(course) +
                 ((typeof course.profFirst === 'undefined' &&
                   typeof course.profLast === 'undefined') ||
                 (typeof course.prefix === 'undefined' &&

--- a/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -142,7 +142,13 @@ function Row({
         </TableCell>
         <TableCell component="th" scope="row">
           <Typography className="leading-tight text-lg text-gray-600 dark:text-gray-200">
-            {searchQueryLabel(course)}
+            {searchQueryLabel(course) +
+              ((typeof course.profFirst === 'undefined' &&
+                typeof course.profLast === 'undefined') ||
+              (typeof course.prefix === 'undefined' &&
+                typeof course.number === 'undefined')
+                ? ' (Overall)'
+                : '')}
           </Typography>
         </TableCell>
         <TableCell align="right">

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -54,31 +54,31 @@ function removeDuplicates(array: SearchQuery[]) {
 
 //Fetch course+prof combos matching a specific course/prof
 function combosSearchResultsFetch(
-  searchTerms: SearchQuery[],
+  searchTerm: SearchQuery,
   controller: AbortController,
-): Promise<SearchQuery[]>[] {
-  return searchTerms.map((searchTerm) => {
-    return fetchWithCache(
-      '/api/combo?input=' + searchQueryLabel(searchTerm),
-      cacheIndexNebula,
-      expireTime,
-      {
-        // use the search terms to fetch all the result course-professor combinations
-        signal: controller.signal,
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-        },
+): Promise<SearchQuery[]> {
+  return fetchWithCache(
+    '/api/combo?input=' + searchQueryLabel(searchTerm),
+    cacheIndexNebula,
+    expireTime,
+    {
+      // use the search terms to fetch all the result course-professor combinations
+      signal: controller.signal,
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
       },
-    ).then((response) => {
-      if (response.message !== 'success') {
-        throw new Error(response.message);
-      }
-      return response.data.map((obj: SearchQuery) => ({
+    },
+  ).then((response) => {
+    if (response.message !== 'success') {
+      throw new Error(response.message);
+    }
+    return [searchTerm].concat(
+      response.data.map((obj: SearchQuery) => ({
         ...searchTerm,
         ...obj,
-      }));
-    });
+      })),
+    );
   });
 }
 
@@ -90,30 +90,32 @@ function fetchSearchResults(
   filterTerms: SearchQuery[], //filterTerms is blank if the searchTerms are ALL courses or ALL professors
   controller: AbortController,
 ) {
-  return Promise.all(combosSearchResultsFetch(searchTerms, controller)).then(
-    (allSearchTermResults: SearchQuery[][]) => {
-      const results: SearchQuery[] = [];
-      allSearchTermResults.map((searchTermResults) =>
-        searchTermResults.map((searchTermResult) => {
-          if (filterTerms.length > 0) {
-            filterTerms.map((filterTerm) => {
-              if (
-                (filterTerm.profFirst === searchTermResult.profFirst &&
-                  filterTerm.profLast === searchTermResult.profLast) ||
-                (filterTerm.prefix === searchTermResult.prefix &&
-                  filterTerm.number === searchTermResult.number)
-              ) {
-                results.push(searchTermResult);
-              }
-            });
-          } else {
-            results.push(searchTermResult);
-          }
-        }),
-      );
-      return results;
-    },
-  );
+  return Promise.all(
+    searchTerms.map((searchTerm) =>
+      combosSearchResultsFetch(searchTerm, controller),
+    ),
+  ).then((allSearchTermResults: SearchQuery[][]) => {
+    const results: SearchQuery[] = [];
+    allSearchTermResults.map((searchTermResults) =>
+      searchTermResults.map((searchTermResult) => {
+        if (filterTerms.length > 0) {
+          filterTerms.map((filterTerm) => {
+            if (
+              (filterTerm.profFirst === searchTermResult.profFirst &&
+                filterTerm.profLast === searchTermResult.profLast) ||
+              (filterTerm.prefix === searchTermResult.prefix &&
+                filterTerm.number === searchTermResult.number)
+            ) {
+              results.push(searchTermResult);
+            }
+          });
+        } else {
+          results.push(searchTermResult);
+        }
+      }),
+    );
+    return results;
+  });
 }
 
 //Find GPA, total, and grade_distribution based on including some set of semesters


### PR DESCRIPTION
As discussed in last Trends meeting, the move to the combos api route removed the overall results for single prof or course searches. This PR readds that by just adding the searched value locally to the results of the call to the combo api.