### PR TITLE
Fix name/credit hours for special courses

### DIFF
--- a/src/components/common/CourseOverview/courseOverview.tsx
+++ b/src/components/common/CourseOverview/courseOverview.tsx
@@ -28,10 +28,16 @@ function parseDescription(course: CourseData): {
   creditHours: string;
 } {
   //extracts info from the course description and formats it
-  const [descriptionBeforeCreditHours, descriptionAfterCreditHours] = course.description.split(/\([\d-]{0,3} semester credit hour[s]?\)/);
+  const [descriptionBeforeCreditHours, descriptionAfterCreditHours] =
+    course.description.split(/\([\d-]{0,3} semester credit hour[s]?\)/);
   let formattedDescription = descriptionAfterCreditHours || course.description;
-  const courseTitle = descriptionAfterCreditHours ? descriptionBeforeCreditHours.split(course.course_number + " - ")[1] : course.title;
-  const creditHours = course.course_number[1] =='V' ? course.description.split(" semester credit hours)")[0].split("(")[1] : course.credit_hours.toString();
+  const courseTitle = descriptionAfterCreditHours
+    ? descriptionBeforeCreditHours.split(course.course_number + ' - ')[1]
+    : course.title;
+  const creditHours =
+    course.course_number[1] == 'V'
+      ? course.description.split(' semester credit hours)')[0].split('(')[1]
+      : course.credit_hours.toString();
 
   const requisites = ['', '', '']; //holds the text (or empty) for 'Prerequisites', 'Corequisites', and 'Prerequisites or Corequisites'
   const requisiteNames = [
@@ -184,7 +190,14 @@ function parseDescription(course: CourseData): {
       formattedDescription.lastIndexOf('.') + 1,
     );
 
-  return { formattedDescription, requisites, sameAsText, offeringFrequency, courseTitle, creditHours };
+  return {
+    formattedDescription,
+    requisites,
+    sameAsText,
+    offeringFrequency,
+    courseTitle,
+    creditHours,
+  };
 }
 
 const CourseOverview = ({ course, grades }: CourseOverviewProps) => {
@@ -260,23 +273,22 @@ const CourseOverview = ({ course, grades }: CourseOverviewProps) => {
     courseData.state === 'done' &&
     typeof courseData.data !== 'undefined'
   ) {
-    const { formattedDescription, requisites, sameAsText, offeringFrequency, courseTitle, creditHours } =
-      parseDescription(courseData.data);
+    const {
+      formattedDescription,
+      requisites,
+      sameAsText,
+      offeringFrequency,
+      courseTitle,
+      creditHours,
+    } = parseDescription(courseData.data);
     courseComponent = (
       <>
-        <p className="text-2xl font-bold text-center">
-          {courseTitle}
-        </p>
+        <p className="text-2xl font-bold text-center">{courseTitle}</p>
         <p className="text-lg font-semibold text-center">
           {searchQueryLabel(course) + ' ' + sameAsText}
         </p>
         <p className="font-semibold">{courseData.data.school}</p>
-        <p>
-          {formattedDescription +
-            ' ' +
-            creditHours +
-            ' credit hours.'}
-        </p>
+        <p>{formattedDescription + ' ' + creditHours + ' credit hours.'}</p>
         {requisites.map((requisite, index) => {
           if (requisite === '') {
             return null;

--- a/src/components/common/CourseOverview/courseOverview.tsx
+++ b/src/components/common/CourseOverview/courseOverview.tsx
@@ -28,10 +28,10 @@ function parseDescription(course: CourseData): {
   creditHours: string;
 } {
   //extracts info from the course description and formats it
-  const [descriptionBeforeCreditHours, descriptionAfterCreditHours] = course.description.split(/\([\d\-]{0,3} semester credit hour[s]?\)/);
+  const [descriptionBeforeCreditHours, descriptionAfterCreditHours] = course.description.split(/\([\d-]{0,3} semester credit hour[s]?\)/);
   let formattedDescription = descriptionAfterCreditHours || course.description;
   const courseTitle = descriptionAfterCreditHours ? descriptionBeforeCreditHours.split(course.course_number + " - ")[1] : course.title;
-  const creditHours = course.course_number[1] =='V' ? course.description.split(" semester credit hours\)")[0].split("(")[1] : course.credit_hours.toString();
+  const creditHours = course.course_number[1] =='V' ? course.description.split(" semester credit hours)")[0].split("(")[1] : course.credit_hours.toString();
 
   const requisites = ['', '', '']; //holds the text (or empty) for 'Prerequisites', 'Corequisites', and 'Prerequisites or Corequisites'
   const requisiteNames = [

--- a/src/components/common/CourseOverview/courseOverview.tsx
+++ b/src/components/common/CourseOverview/courseOverview.tsx
@@ -216,10 +216,9 @@ const CourseOverview = ({ course, grades }: CourseOverviewProps) => {
       })
       .then((response: CourseData[]) => {
         response.sort((a, b) => b.catalog_year - a.catalog_year); // sort by year descending, so index 0 has the most recent year
-        var selectedCourse = response[0];
         setCourseData({
           state: typeof response !== 'undefined' ? 'done' : 'error',
-          data: selectedCourse as CourseData,
+          data: response[0] as CourseData,
         });
       })
 
@@ -261,7 +260,7 @@ const CourseOverview = ({ course, grades }: CourseOverviewProps) => {
     courseData.state === 'done' &&
     typeof courseData.data !== 'undefined'
   ) {
-    const { formattedDescription, requisites, sameAsText, offeringFrequency, courseTitle } =
+    const { formattedDescription, requisites, sameAsText, offeringFrequency, courseTitle, creditHours } =
       parseDescription(courseData.data);
     courseComponent = (
       <>
@@ -275,7 +274,7 @@ const CourseOverview = ({ course, grades }: CourseOverviewProps) => {
         <p>
           {formattedDescription +
             ' ' +
-            courseData.data.credit_hours +
+            creditHours +
             ' credit hours.'}
         </p>
         {requisites.map((requisite, index) => {


### PR DESCRIPTION
## Overview
Resolves #183, also resolves #173.

## What Changed

In CourseOverview.tsx, I replaced the course name we get from the Nebula API with one parsed from the course description. I did the same with credit hours **only when the course has variable credit hours.** I replaced our parsing technique to use some simple regex that accounts for a variable number of credit hours. 

## Other Notes

We still might need some further testing to make sure none of our other course names/descriptions were affected by this. The special courses listed in the issue all have the correct name now, and other random courses seem to be working correctly.
