### PR TITLE
Updated Loading Skeleton Size inside the search result card for RMP data

### DIFF
--- a/src/components/common/SingleProfInfo/singleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/singleProfInfo.tsx
@@ -17,25 +17,25 @@ function SingleProfInfo({ rmp }: Props) {
       <Grid container spacing={2} className="p-4">
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton />
+            <Skeleton variant="rounded" width="10%" height={25}/>
           </p>
           <p>Professor rating</p>
         </Grid>
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton />
+            <Skeleton variant="rounded" width="10%" height={25}/>
           </p>
           <p>Difficulty</p>
         </Grid>
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton />
+            <Skeleton variant="rounded" width="10%" height={25}/>
           </p>
           <p>Ratings given</p>
         </Grid>
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton />
+            <Skeleton variant="rounded" width="10%" height={25}/>
           </p>
           <p>Would take again</p>
         </Grid>

--- a/src/components/common/SingleProfInfo/singleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/singleProfInfo.tsx
@@ -17,25 +17,25 @@ function SingleProfInfo({ rmp }: Props) {
       <Grid container spacing={2} className="p-4">
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton variant="rounded" width="10%" height={25}/>
+            <Skeleton variant="rounded" width="10%" height={25} />
           </p>
           <p>Professor rating</p>
         </Grid>
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton variant="rounded" width="10%" height={25}/>
+            <Skeleton variant="rounded" width="10%" height={25} />
           </p>
           <p>Difficulty</p>
         </Grid>
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton variant="rounded" width="10%" height={25}/>
+            <Skeleton variant="rounded" width="10%" height={25} />
           </p>
           <p>Ratings given</p>
         </Grid>
         <Grid item xs={6}>
           <p className="text-xl font-bold">
-            <Skeleton variant="rounded" width="10%" height={25}/>
+            <Skeleton variant="rounded" width="10%" height={25} />
           </p>
           <p>Would take again</p>
         </Grid>


### PR DESCRIPTION
## Overview

List the GitHub issues containing the issues relevant to this pull request.
     -Resolves Issue #185

Describe your changes here at a high level, describing how this PR fits into the
rest of the project.
     -Resized the loading skeletons placeholders in the Search Result Card with rmp data to better fit the data size they represent. 
     (Made boxes less wide and taller)

## What Changed
    -singleProfInfo.tsx was modified. specifically lines 20, 26, 32, 38

## Other Notes