### PR TITLE
Remove filters on homepage

### DIFF
--- a/src/components/common/Filters/filters.tsx
+++ b/src/components/common/Filters/filters.tsx
@@ -15,15 +15,8 @@ import React, { useEffect, useState } from 'react';
 const minGPAs = ['3.5', '3.0', '2.5', '2.0', '1.5', '1.0', '0.5'];
 const minRatings = ['4.5', '4', '3.5', '3', '2.5', '2', '1.5', '1', '0.5'];
 
-export interface FiltersType {
-  minGPA?: string;
-  minRating?: string;
-}
-
 interface FiltersProps {
   manageQuery?: boolean;
-  path?: string;
-  changeValue?: (value: FiltersType) => void;
   className?: string;
   academicSessions?: string[];
   chosenSessions?: string[];
@@ -35,8 +28,6 @@ interface FiltersProps {
  */
 const Filters = ({
   manageQuery,
-  path,
-  changeValue,
   className,
   academicSessions,
   chosenSessions,
@@ -76,27 +67,11 @@ const Filters = ({
       }
       router.replace(
         {
-          pathname: path,
           query: newQuery,
         },
         undefined,
         { shallow: true },
       );
-    }
-    if (typeof changeValue !== 'undefined') {
-      const newSet: FiltersType = {};
-      if (minGPA !== '') {
-        newSet.minGPA = minGPA;
-      }
-      if (minRating !== '') {
-        newSet.minRating = minRating;
-      }
-      if (newValue !== '') {
-        newSet[toSet] = newValue;
-      } else {
-        delete newSet[toSet];
-      }
-      changeValue(newSet);
     }
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,9 +6,6 @@ import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 
 import Background from '../../public/background.png';
-import Filters, {
-  type FiltersType,
-} from '../components/common/Filters/filters';
 import SearchBar from '../components/common/SearchBar/searchBar';
 import type SearchQuery from '../modules/SearchQuery/SearchQuery';
 import searchQueryLabel from '../modules/searchQueryLabel/searchQueryLabel';
@@ -24,15 +21,12 @@ const Home: NextPage = () => {
     }
   }
 
-  const [filters, setFilters] = useState<FiltersType>({});
-
   const router = useRouter();
   function searchOptionChosen(chosenOptions: SearchQuery[]) {
     if (chosenOptions.length) {
       router.push({
         pathname: '/dashboard',
         query: {
-          ...filters,
           searchTerms: chosenOptions
             .map((el) => searchQueryLabel(el))
             .join(','),
@@ -94,7 +88,6 @@ const Home: NextPage = () => {
             className="mb-3"
             input_className="[&>.MuiInputBase-root]:bg-white [&>.MuiInputBase-root]:dark:bg-haiti"
           />
-          <Filters changeValue={(value) => setFilters(value)} />
         </div>
       </div>
     </>


### PR DESCRIPTION
Resolves #219 

Removes filters on homepage.

My reasoning for this was just there's no reason to filter before seeing all the data, especially since a restrictive filter can make no data show up.