### PR TITLE
Add prof RMP link

### DIFF
--- a/src/components/common/SingleProfInfo/singleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/singleProfInfo.tsx
@@ -1,4 +1,5 @@
 import { Grid, Skeleton } from '@mui/material';
+import Link from 'next/link';
 import React from 'react';
 
 import type { RateMyProfessorData } from '../../../pages/api/ratemyprofessorScraper';
@@ -63,6 +64,17 @@ function SingleProfInfo({ rmp }: Props) {
           {rmp.data.wouldTakeAgainPercentage.toFixed(0) + '%'}
         </p>
         <p>Would take again</p>
+      </Grid>
+      <Grid item xs={12}>
+        <Link
+          href={
+            'https://www.ratemyprofessors.com/professor/' + rmp.data.legacyId
+          }
+          target="_blank"
+          className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+        >
+          Visit Rate My Professors
+        </Link>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
Adds a link to Rate My Professors like on the old Trends and on Skedge.

No matter what we scrape from RMP, linking to the site will still always hold value to users so this is a good thing to do.