### PR TITLE
Fixed Issue 195 - Implement column sort UI (indicating that a column is sortable) 

### DIFF
--- a/src/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -334,7 +334,12 @@ const SearchResultsTable = ({
                   }}
                   sx={{
                     '& .MuiTableSortLabel-icon': {
-                      opacity: '1 !important', // Ensure the arrow is always visible
+                      opacity:
+                        orderBy === 'gpa' ? '1 !important' : '0.8 !important', // Ensure the arrow is always visible
+                      color:
+                        orderBy === 'gpa'
+                          ? 'black !important'
+                          : 'gray !important',
                       visibility: 'visible !important', // Force visibility
                     },
                   }}
@@ -351,7 +356,14 @@ const SearchResultsTable = ({
                   }}
                   sx={{
                     '& .MuiTableSortLabel-icon': {
-                      opacity: '1 !important', // Ensure the arrow is always visible
+                      opacity:
+                        orderBy === 'rating'
+                          ? '1 !important'
+                          : '0.8 !important', // Ensure the arrow is always visible
+                      color:
+                        orderBy === 'rating'
+                          ? 'black !important'
+                          : 'gray !important',
                       visibility: 'visible !important', // Force visibility
                     },
                   }}

--- a/src/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -332,6 +332,12 @@ const SearchResultsTable = ({
                   onClick={() => {
                     handleClick('gpa');
                   }}
+                  sx={{
+                    '& .MuiTableSortLabel-icon': {
+                      opacity: '1 !important', // Ensure the arrow is always visible
+                      visibility: 'visible !important', // Force visibility
+                    },
+                  }}
                 >
                   GPA
                 </TableSortLabel>
@@ -342,6 +348,12 @@ const SearchResultsTable = ({
                   direction={orderBy === 'rating' ? order : 'asc'}
                   onClick={() => {
                     handleClick('rating');
+                  }}
+                  sx={{
+                    '& .MuiTableSortLabel-icon': {
+                      opacity: '1 !important', // Ensure the arrow is always visible
+                      visibility: 'visible !important', // Force visibility
+                    },
                   }}
                 >
                   Rating


### PR DESCRIPTION
## Overview

Resolves #195 

Changes make column header sorting arrow(next to GPA and Rating column headers) visible by default instead of only when hovered over or clicked

## What Changed

Only the "searchResultsTable.tsx" file was edited. Added CSS rules that overrides the default CSS rules for TableSortLabel that makes the arrow not visible by default.