### PR TITLE
Keep RHS tabs mounted

### DIFF
--- a/src/components/common/Carousel/carousel.tsx
+++ b/src/components/common/Carousel/carousel.tsx
@@ -1,6 +1,6 @@
 import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { TabNavMenu } from '../../navigation/tabNavMenu/tabNavMenu';
 
@@ -38,21 +38,19 @@ const variants = {
  * @param props the props passed from the parent component
  * @returns
  */
-export const Carousel = ({ names, children }: CarouselProps) => {
+const Carousel = ({ names, children }: CarouselProps) => {
   // The card currently being displayed
-  const [currentCard, setCard] = useState(0);
+  const [currentCard, setCurrentCard] = useState(0);
   // The Direction that the card is moving in
-  const [direction, setDir] = useState(0);
+  const [direction, setDirection] = useState(0);
 
   /**
-   * When children change, ensure currentCard is within valid bounds
+   * On each re-render, ensure currentCard is within valid bounds
    */
-  useEffect(() => {
-    if (Array.isArray(children) && currentCard >= children.length) {
-      // If currentCard is out of bounds, reset it to 0
-      setCard(0);
-    }
-  }, [children, currentCard]);
+  if (Array.isArray(children) && currentCard >= children.length) {
+    // If currentCard is out of bounds, reset it to 0
+    setCurrentCard(0);
+  }
 
   /**
    * Turn
@@ -60,8 +58,8 @@ export const Carousel = ({ names, children }: CarouselProps) => {
    * @param displacement a positive value will cause the card to move right, negative value cause card to move left
    */
   const turn = (displacement: number) => {
-    setDir(displacement);
-    setCard((prevCard) => {
+    setDirection(displacement);
+    setCurrentCard((prevCard) => {
       const newCard = prevCard + displacement;
       if (Array.isArray(children)) {
         return Math.max(0, Math.min(newCard, children.length - 1));
@@ -91,7 +89,16 @@ export const Carousel = ({ names, children }: CarouselProps) => {
               opacity: { duration: 0.2 },
             }}
           >
-            {Array.isArray(children) ? children[currentCard] : children}
+            {Array.isArray(children)
+              ? children.map((child, index) => (
+                  <div
+                    key={index}
+                    className={index === currentCard ? 'block' : 'hidden'}
+                  >
+                    {child}
+                  </div>
+                ))
+              : children}
           </motion.div>
         </div>
       </AnimatePresence>


### PR DESCRIPTION
Resolves #186 

This prevents a new API call for each tab switch as the component is not unmounted every time you switch away, just set to `display: none`.