### PR TITLE
Make RHS sticky when scrolling through search results

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -740,16 +740,12 @@ export const Dashboard: NextPage = () => {
               removeFromCompare={removeFromCompare}
             />
           </Grid>
-          <Grid
-            item
-            xs={false}
-            sm={5}
-            md={5}
-            className="sticky bottom-2 h-min gridsm:min-h-screen w-full"
-          >
-            <Card>
-              <Carousel names={names}>{tabs}</Carousel>
-            </Card>
+          <Grid item xs={false} sm={5} md={5} className="w-full">
+            <div className="sticky top-0 gridsm:max-h-screen overflow-y-auto">
+              <Card>
+                <Carousel names={names}>{tabs}</Carousel>
+              </Card>
+            </div>
           </Grid>
         </Grid>
       </>

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -740,7 +740,13 @@ export const Dashboard: NextPage = () => {
               removeFromCompare={removeFromCompare}
             />
           </Grid>
-          <Grid item xs={false} sm={5} md={5} className="w-full">
+          <Grid
+            item
+            xs={false}
+            sm={5}
+            md={5}
+            className="sticky bottom-2 h-min gridsm:min-h-screen w-full"
+          >
             <Card>
               <Carousel names={names}>{tabs}</Carousel>
             </Card>

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -741,7 +741,7 @@ export const Dashboard: NextPage = () => {
             />
           </Grid>
           <Grid item xs={false} sm={5} md={5} className="w-full">
-            <div className="sticky top-0 gridsm:max-h-screen overflow-y-auto">
+            <div className="sticky top-0 gridsm:max-h-screen overflow-y-auto pt-4">
               <Card>
                 <Carousel names={names}>{tabs}</Carousel>
               </Card>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
     screens: {
       short: { raw: '(max-height: 200px)' },
       xs: '400px',
+      gridsm: '600px',
       sm: '640px',
       // => @media (min-width: 640px) { ... }
 


### PR DESCRIPTION
## Overview

Resolves #212
Makes sure RHS is visible through the entire page.

## What Changed
I made the RHS sticky. I applied the sticky property to the bottom of the grid item because I figured that when the RHS is taller than the screen, users would want to be able to see the bottom of the RHS before scrolling to the bottom of the page.

This is a little bit hacky (and has the opposite problem when scrolling back up, especially on the compare view), so if y'all think it's better we can also use the traditional sticky prop:
<details>
<summary>Expand to see GIF with traditional prop</summary>
With traditional sticky prop:

![scrollStickyTop](https://github.com/user-attachments/assets/f16a8032-c902-4a9a-899e-3c75d7d6b8bc)
</details>

<details>
<summary>GIFs with my version for comparison</summary>
With custom sticky prop:

![scrollStickyBottomShort](https://github.com/user-attachments/assets/6da4a008-b7fc-4d1e-a342-dbe8553cfaed)

![scrollStickyBottom](https://github.com/user-attachments/assets/024b4c36-28df-4be8-bc28-5a57a117ad20)
</details>

This doesn't seem to affect mobile from my testing.

Also I know CSS can be weird--I just tested this on Chrome and Firefox, so if someone wants to try it with Safari that would be good!


