### PR TITLE
Guide user and prevent empty searches

### DIFF
--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -16,7 +16,6 @@ import searchQueryLabel from '../../../modules/searchQueryLabel/searchQueryLabel
 interface SearchProps {
   manageQuery?: 'onSelect' | 'onChange';
   onSelect?: (value: SearchQuery[]) => void;
-  onChange?: (value: SearchQuery[]) => void;
   className?: string;
   input_className?: string;
 }
@@ -31,7 +30,6 @@ let wasEmpty = false; // tracks if the searchbar was empty before the new entry 
 const SearchBar = ({
   manageQuery,
   onSelect,
-  onChange,
   className,
   input_className,
 }: SearchProps) => {
@@ -67,9 +65,6 @@ const SearchBar = ({
   //update url with what's in value
   function updateQueries(newValue: SearchQuery[]) {
     if (typeof manageQuery !== 'undefined' && router.isReady) {
-      if (typeof onChange !== 'undefined') {
-        onChange(newValue);
-      }
       const newQuery = router.query;
       if (newValue.length > 0) {
         newQuery.searchTerms = newValue
@@ -165,9 +160,6 @@ const SearchBar = ({
 
   //update parent and queries
   function onChange_internal(newValue: SearchQuery[]) {
-    if (typeof onChange !== 'undefined') {
-      onChange(newValue);
-    }
     if (newValue.length == 0) {
       wasEmpty = true; // so that the next search creates a new navigation entry (push())
     }

--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -192,7 +192,7 @@ const SearchBar = ({
   }
 
   //update parent and queries
-  function onSelect_internal(newValue: SearchQuery[]) {    
+  function onSelect_internal(newValue: SearchQuery[]) {
     setErrorTooltip(!newValue.length); //Check if tooltip needs to be displayed
     if (typeof onSelect !== 'undefined') {
       onSelect(newValue);
@@ -335,7 +335,7 @@ const SearchBar = ({
         }}
       />
       <Tooltip
-        title="Select an option before searching" 
+        title="Select an option before searching"
         placement="top"
         open={openErrorTooltip}
         onOpen={() => setErrorTooltip(true)}
@@ -348,8 +348,11 @@ const SearchBar = ({
           variant="contained"
           disableElevation
           size="large"
-          className={value.length == 0 ? "shrink-0 normal-case bg-royal hover:bg-royalDark text-cornflower-100"
-                                          : "shrink-0 normal-case bg-royal hover:bg-royalDark"} //darkens the text when no valid search terms are entered (pseudo-disables the search button)
+          className={
+            value.length == 0
+              ? 'shrink-0 normal-case bg-royal hover:bg-royalDark text-cornflower-100'
+              : 'shrink-0 normal-case bg-royal hover:bg-royalDark'
+          } //darkens the text when no valid search terms are entered (pseudo-disables the search button)
           onClick={() => onSelect_internal(value)}
         >
           Search

--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, Button, TextField } from '@mui/material';
+import { Autocomplete, Button, TextField, Tooltip } from '@mui/material';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
 import { useRouter } from 'next/router';
@@ -39,6 +39,7 @@ const SearchBar = ({
   const [options, setOptions] = useState<SearchQuery[]>([]);
   //initial loading prop for first load
   const [loading, setLoading] = useState(false);
+  const [openErrorTooltip, setErrorTooltip] = React.useState(false);
 
   //text in search
   const [inputValue, _setInputValue] = useState('');
@@ -191,7 +192,8 @@ const SearchBar = ({
   }
 
   //update parent and queries
-  function onSelect_internal(newValue: SearchQuery[]) {
+  function onSelect_internal(newValue: SearchQuery[]) {    
+    setErrorTooltip(!newValue.length); //Check if tooltip needs to be displayed
     if (typeof onSelect !== 'undefined') {
       onSelect(newValue);
     }
@@ -332,15 +334,27 @@ const SearchBar = ({
           );
         }}
       />
-      <Button
-        variant="contained"
-        disableElevation
-        size="large"
-        className="shrink-0 normal-case bg-royal hover:bg-royalDark"
-        onClick={() => onSelect_internal(value)}
+      <Tooltip
+        title="Select an option before searching" 
+        placement="top"
+        open={openErrorTooltip}
+        onOpen={() => setErrorTooltip(true)}
+        onClose={() => setErrorTooltip(false)}
+        disableFocusListener
+        disableHoverListener
+        disableTouchListener
       >
-        Search
-      </Button>
+        <Button
+          variant="contained"
+          disableElevation
+          size="large"
+          className={value.length == 0 ? "shrink-0 normal-case bg-royal hover:bg-royalDark text-cornflower-100"
+                                          : "shrink-0 normal-case bg-royal hover:bg-royalDark"} //darkens the text when no valid search terms are entered (pseudo-disables the search button)
+          onClick={() => onSelect_internal(value)}
+        >
+          Search
+        </Button>
+      </Tooltip>
     </div>
   );
 };

--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -327,7 +327,7 @@ const SearchBar = ({
         }}
       />
       <Tooltip
-        title="Select an option before searching"
+        title="Select a course or professor before searching"
         placement="top"
         open={openErrorTooltip}
         onOpen={() => setErrorTooltip(true)}
@@ -342,7 +342,7 @@ const SearchBar = ({
           size="large"
           className={
             'shrink-0 normal-case bg-royal hover:bg-royalDark' +
-            (value.length == 0 ? ' text-cornflower-100' : '')
+            (value.length == 0 ? ' text-cornflower-200' : '')
           } //darkens the text when no valid search terms are entered (pseudo-disables the search button)
           onClick={() => onSelect_internal(value)}
         >

--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -349,9 +349,8 @@ const SearchBar = ({
           disableElevation
           size="large"
           className={
-            value.length == 0
-              ? 'shrink-0 normal-case bg-royal hover:bg-royalDark text-cornflower-100'
-              : 'shrink-0 normal-case bg-royal hover:bg-royalDark'
+            'shrink-0 normal-case bg-royal hover:bg-royalDark' +
+            (value.length == 0 ? ' text-cornflower-100' : '')
           } //darkens the text when no valid search terms are entered (pseudo-disables the search button)
           onClick={() => onSelect_internal(value)}
         >

--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -190,7 +190,7 @@ const SearchBar = ({
     if (typeof onSelect !== 'undefined') {
       onSelect(newValue);
     }
-    if (manageQuery === 'onSelect') {
+    if (newValue.length && manageQuery === 'onSelect') {
       updateQueries(newValue);
     }
   }

--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -179,6 +179,7 @@ const SearchBar = ({
 
   //change all values
   function updateValue(newValue: SearchQuery[]) {
+    if (newValue.length) setErrorTooltip(false); //close the tooltip if there is at least 1 valid search term
     setValue(newValue);
     onChange_internal(newValue);
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,6 @@ import searchQueryLabel from '../modules/searchQueryLabel/searchQueryLabel';
  * Returns the home page with Nebula Branding, waved background, and SearchBar Components
  */
 const Home: NextPage = () => {
-
   const router = useRouter();
   function searchOptionChosen(chosenOptions: SearchQuery[]) {
     if (chosenOptions.length) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,8 @@ import searchQueryLabel from '../modules/searchQueryLabel/searchQueryLabel';
  * Returns the home page with Nebula Branding, waved background, and SearchBar Components
  */
 const Home: NextPage = () => {
-  function searchOptionsChange(chosenOptions: SearchQuery[]) { // does nothing on change
+  function searchOptionsChange(chosenOptions: SearchQuery[]) {
+    // does nothing on change
   }
 
   const router = useRouter();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,9 +13,6 @@ import searchQueryLabel from '../modules/searchQueryLabel/searchQueryLabel';
  * Returns the home page with Nebula Branding, waved background, and SearchBar Components
  */
 const Home: NextPage = () => {
-  function searchOptionsChange(chosenOptions: SearchQuery[]) {
-    // does nothing on change
-  }
 
   const router = useRouter();
   function searchOptionChosen(chosenOptions: SearchQuery[]) {
@@ -73,7 +70,6 @@ const Home: NextPage = () => {
           </p>
           <SearchBar
             onSelect={searchOptionChosen}
-            onChange={searchOptionsChange}
             className="mb-3"
             input_className="[&>.MuiInputBase-root]:bg-white [&>.MuiInputBase-root]:dark:bg-haiti"
           />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { Alert } from '@mui/material';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
@@ -14,11 +13,7 @@ import searchQueryLabel from '../modules/searchQueryLabel/searchQueryLabel';
  * Returns the home page with Nebula Branding, waved background, and SearchBar Components
  */
 const Home: NextPage = () => {
-  const [errorMessage, setErrorMessage] = useState(false);
-  function searchOptionsChange(chosenOptions: SearchQuery[]) {
-    if (chosenOptions.length) {
-      setErrorMessage(false);
-    }
+  function searchOptionsChange(chosenOptions: SearchQuery[]) { // does nothing on change
   }
 
   const router = useRouter();
@@ -32,8 +27,6 @@ const Home: NextPage = () => {
             .join(','),
         },
       });
-    } else {
-      setErrorMessage(true);
     }
   }
 
@@ -77,11 +70,6 @@ const Home: NextPage = () => {
             Explore and compare past grades, professor ratings, and reviews to
             find the perfect class.
           </p>
-          {errorMessage && (
-            <Alert severity="error" className="mb-2">
-              Select an option before searching.
-            </Alert>
-          )}
           <SearchBar
             onSelect={searchOptionChosen}
             onChange={searchOptionsChange}


### PR DESCRIPTION
## Overview

#215

Grey out search button text and show tooltip if user tries to empty search

## What Changed

Search button text is not white by default, and becomes white once the user selects at least 1 valid search term from autocomplete
Removed the alert from index.tsx that used to display above the search bar when the user tried to empty search
Transferred the text into a tooltip that pops up above the search button if the user clicks enter or the button without any search terms