### PR TITLE
Card expands when clicked anywhere along the row

### DIFF
--- a/src/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -110,7 +110,10 @@ function Row({
 
   return (
     <>
-      <TableRow sx={{ '& > *': { borderBottom: 'unset' } }}>
+      <TableRow
+        onClick={() => setOpen(!open)} // opens/closes the card by clicking anywhere on the row
+        sx={{ '& > *': { borderBottom: 'unset' } }}
+      >
         <TableCell>
           <IconButton
             aria-label="expand row"
@@ -121,7 +124,11 @@ function Row({
             <KeyboardArrowIcon />
           </IconButton>
         </TableCell>
-        <TableCell>
+        <TableCell
+          onClick={
+            (e) => e.stopPropagation() // prevents opening/closing the card when clicking on the compare checkbox
+          }
+        >
           <Checkbox
             checked={inCompare}
             onClick={() => {


### PR DESCRIPTION
## Overview

Closes https://github.com/UTDNebula/utd-trends/issues/202

## What Changed

Added an onClick for the TableRow that triggers when the row is clicked anywhere
**except** when you click on the compare checkbox.

## Other Notes

There is a deadzone between the checkbox and the name label for the result where clicking does not trigger the row expansion.