### PR TITLE
Rmp fix

### DIFF
--- a/src/pages/api/ratemyprofessorScraper.ts
+++ b/src/pages/api/ratemyprofessorScraper.ts
@@ -109,7 +109,8 @@ export default function handler(
     return;
   }
   return new Promise<void>((resolve) => {
-    const name = profFirst.split(' ')[0] + ' ' + profLast;
+    profFirst = profFirst.split(' ')[0]
+    const name = profFirst + ' ' + profLast;
 
     // create fetch object for professor
     const graphQlUrlProp = getGraphQlUrlProp(name);

--- a/src/pages/api/ratemyprofessorScraper.ts
+++ b/src/pages/api/ratemyprofessorScraper.ts
@@ -109,8 +109,8 @@ export default function handler(
     return;
   }
   return new Promise<void>((resolve) => {
-    profFirst = profFirst.split(' ')[0]
-    const name = profFirst + ' ' + profLast;
+    const singleProfFirst = profFirst.split(' ')[0];
+    const name = singleProfFirst + ' ' + profLast;
 
     // create fetch object for professor
     const graphQlUrlProp = getGraphQlUrlProp(name);
@@ -134,7 +134,7 @@ export default function handler(
         const professors = response.data.newSearch.teachers.edges.filter(
           (prof: { node: RMPInterface }) =>
             prof.node.school.name === SCHOOL_NAME &&
-            prof.node.firstName.includes(profFirst) &&
+            prof.node.firstName.includes(singleProfFirst) &&
             prof.node.lastName.includes(profLast),
         );
         //Pick prof instance with most ratings


### PR DESCRIPTION
Noticed the way this runs, when it checks if the returned prof match the given name, it check that the whole "first name" is in the returned name. So if a name is `first middle last`, it would look for `first middle` in the rmp first, and return no data found.