### PR TITLE
Change dashboard page name

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -763,7 +763,7 @@ export const Dashboard: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Dashboard - Nebula Labs</title>
+        <title>Results - Nebula Labs</title>
         <link
           rel="canonical"
           href="https://trends.utdnebula.com/dashboard"

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -763,6 +763,7 @@ export const Dashboard: NextPage = () => {
   return (
     <>
       <Head>
+        <title>Dashboard - Nebula Labs</title>
         <link
           rel="canonical"
           href="https://trends.utdnebula.com/dashboard"


### PR DESCRIPTION
Wanted to change the dashboard page name so the below metric in Google Analytics would have some meaning. I named it "Dashboard - UTD Trends" but "Results - UTD Trends" might be more appropriate.

![image](https://github.com/user-attachments/assets/56f91ec3-03f3-4cde-9511-69b36cec5126)
