### PR TITLE
Did the wrong name for the dashboard

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -763,7 +763,7 @@ export const Dashboard: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Results - Nebula Labs</title>
+        <title>Results - UTD Trends</title>
         <link
           rel="canonical"
           href="https://trends.utdnebula.com/dashboard"


### PR DESCRIPTION
In #261 changed the dashboard name to "Results - Nebula Labs" instead of "Results - UTD Trends".
Oops