### PR TITLE
Add all course or professor sessions from RHS to academic sessions

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -275,6 +275,26 @@ export const Dashboard: NextPage = () => {
           );
         }
       });
+      if (
+        professorSearchTerms.length === 1 &&
+        grades[searchQueryLabel(professorSearchTerms[0])] &&
+        grades[searchQueryLabel(professorSearchTerms[0])].state === 'done'
+      ) {
+        const entry = grades[searchQueryLabel(professorSearchTerms[0])];
+        if (entry && entry.state === 'done') {
+          addAcademicSessions(entry.data.grades.map((session) => session._id));
+        }
+      }
+      if (
+        courseSearchTerms.length === 1 &&
+        grades[searchQueryLabel(courseSearchTerms[0])] &&
+        grades[searchQueryLabel(courseSearchTerms[0])].state === 'done'
+      ) {
+        const entry = grades[searchQueryLabel(courseSearchTerms[0])];
+        if (entry && entry.state === 'done') {
+          addAcademicSessions(entry.data.grades.map((session) => session._id));
+        }
+      }
 
       //To cancel on rerender
       const controller = new AbortController();


### PR DESCRIPTION
## Overview
Resolves #256 

Added all the semesters in which a professor on RHS taught or a course on the RHS was taught to the academic sessions on any new search without refreshing the page. The behavior now matches what would happen if you refreshed the page.

## What Changed
On the RHS Professor and Course overview pages, this means that changing searches no longer changes the grade distribution (or # of grades, average GPA, etc.). Filtering by semester still changes grade distributions on both LHS and RHS. On the LHS, it seems to be the same. 
This change does mean that for most course/professor combinations, the semester dropdown filter now includes more course and professor combinations in which the combo wasn't taught. Checking or unchecking these boxes doesn't change anything on the LHS, but it does change the distributions on the LHS.
