### PR TITLE
Fix browser nav & remove the need to double-ENTER on the searchbar

### DIFF
--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -26,7 +26,6 @@ interface SearchProps {
  *
  * Styled for the splash page
  */
-let wasEmpty = false; // tracks if the searchbar was empty before the new entry (to create a new browser navigation entry push())
 const SearchBar = ({
   manageQuery,
   onSelect,
@@ -73,25 +72,13 @@ const SearchBar = ({
       } else {
         delete newQuery.searchTerms;
       }
-      if (wasEmpty) {
-        // if the searchbar was cleared before this entry,
-        router.push(
-          {
-            query: router.query,
-          },
-          undefined,
-          { shallow: true },
-        );
-        wasEmpty = false;
-      } //otherwise, just update the current navigation entry query
-      else
-        router.replace(
-          {
-            query: newQuery,
-          },
-          undefined,
-          { shallow: true },
-        );
+      router.push(
+        {
+          query: router.query,
+        },
+        undefined,
+        { shallow: true },
+      );
     }
   }
 
@@ -159,9 +146,6 @@ const SearchBar = ({
 
   //update parent and queries
   function onChange_internal(newValue: SearchQuery[]) {
-    if (newValue.length == 0) {
-      wasEmpty = true; // so that the next search creates a new navigation entry (push())
-    }
     if (manageQuery === 'onChange') {
       updateQueries(newValue);
     }

--- a/src/components/common/SearchBar/searchBar.tsx
+++ b/src/components/common/SearchBar/searchBar.tsx
@@ -165,6 +165,7 @@ const SearchBar = ({
     if (newValue.length) setErrorTooltip(false); //close the tooltip if there is at least 1 valid search term
     setValue(newValue);
     onChange_internal(newValue);
+    onSelect_internal(newValue); // clicking enter to select a autocomplete suggestion triggers a new search (it also 'Enters' for the searchbar)
   }
 
   //update parent and queries

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -231,7 +231,7 @@ function fetchRmpData(
 export const Dashboard: NextPage = () => {
   const router = useRouter();
 
-  const [pageTitle, setPageTitle] = useState<String>('');
+  const [pageTitle, setPageTitle] = useState<string>('');
   //Searches seperated into courses and professors to create combos
   const [courses, setCourses] = useState<SearchQuery[]>([]);
   const [professors, setProfessors] = useState<SearchQuery[]>([]);
@@ -342,7 +342,7 @@ export const Dashboard: NextPage = () => {
     courseSearchTerms: SearchQuery[],
     professorSearchTerms: SearchQuery[],
   ) {
-    var str = '';
+    let str = '';
     courseSearchTerms.map((term) => {
       str += searchQueryLabel(term) + ', ';
     });

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -231,6 +231,7 @@ function fetchRmpData(
 export const Dashboard: NextPage = () => {
   const router = useRouter();
 
+  const [pageTitle, setPageTitle] = useState<String>('');
   //Searches seperated into courses and professors to create combos
   const [courses, setCourses] = useState<SearchQuery[]>([]);
   const [professors, setProfessors] = useState<SearchQuery[]>([]);
@@ -263,6 +264,8 @@ export const Dashboard: NextPage = () => {
       });
       setCourses(courseSearchTerms);
       setProfessors(professorSearchTerms);
+
+      updatePageTitle(courseSearchTerms, professorSearchTerms);
 
       //Clear fetched data
       setResults({ state: 'loading' });
@@ -334,6 +337,20 @@ export const Dashboard: NextPage = () => {
       };
     }
   }, [router.isReady, router.query.searchTerms]);
+
+  function updatePageTitle(
+    courseSearchTerms: SearchQuery[],
+    professorSearchTerms: SearchQuery[],
+  ) {
+    var str = '';
+    courseSearchTerms.map((term) => {
+      str += searchQueryLabel(term) + ', ';
+    });
+    professorSearchTerms.map((term) => {
+      str += searchQueryLabel(term) + ', ';
+    });
+    setPageTitle(str);
+  }
 
   //Compiled list of academic sessions grade data is available for
   const [academicSessions, setAcademicSessions] = useState<string[]>([]);
@@ -763,7 +780,7 @@ export const Dashboard: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Results - UTD Trends</title>
+        <title>{pageTitle + ' - UTD TRENDS'}</title>
         <link
           rel="canonical"
           href="https://trends.utdnebula.com/dashboard"


### PR DESCRIPTION
Browser Nav:
 - More intuitive (normal expectation) browser history behavior: every new search triggers an entry on the history stack
 - Dynamic Page titles: in the format "Result - CS 1200, John Cole - UTD TRENDS"

Searchbar ENTER:
- Previous Behavior: Type cs1200, click enter to add the autocomplete suggestion to the searchbar, then click again
- New Behavior: Type cs1200, click enter -> Adds the autocomplete suggestion to the searchbar AND triggers the search without an additional keypress
    - _Note:_ typing cs1200 and then clicking space allows you to add the autocomplete to the searchbar's searchqueries, but does not trigger a new search