### PR TITLE
251 feature request compare colors on lhs

### DIFF
--- a/src/components/common/Compare/compare.tsx
+++ b/src/components/common/Compare/compare.tsx
@@ -15,6 +15,7 @@ type CompareProps = {
   grades: { [key: string]: GenericFetchedData<GradesType> };
   rmp: { [key: string]: GenericFetchedData<RMPInterface> };
   removeFromCompare: { (arg0: SearchQuery): void };
+  colorMap: { [key: string]: string };
 };
 
 function convertNumbersToPercents(distribution: GradesType): number[] {
@@ -24,7 +25,7 @@ function convertNumbersToPercents(distribution: GradesType): number[] {
   );
 }
 
-const Compare = ({ courses, grades, rmp, removeFromCompare }: CompareProps) => {
+const Compare = ({ courses, grades, rmp, removeFromCompare, colorMap }: CompareProps) => {
   if (courses.length === 0) {
     return <p>Click a checkbox to add something to compare.</p>;
   }
@@ -90,6 +91,7 @@ const Compare = ({ courses, grades, rmp, removeFromCompare }: CompareProps) => {
         grades={grades}
         rmp={rmp}
         removeFromCompare={removeFromCompare}
+        colorMap={colorMap}
       />
     </div>
   );

--- a/src/components/common/Compare/compare.tsx
+++ b/src/components/common/Compare/compare.tsx
@@ -25,7 +25,13 @@ function convertNumbersToPercents(distribution: GradesType): number[] {
   );
 }
 
-const Compare = ({ courses, grades, rmp, removeFromCompare, colorMap }: CompareProps) => {
+const Compare = ({
+  courses,
+  grades,
+  rmp,
+  removeFromCompare,
+  colorMap,
+}: CompareProps) => {
   if (courses.length === 0) {
     return <p>Click a checkbox to add something to compare.</p>;
   }

--- a/src/components/common/CompareTable/compareTable.tsx
+++ b/src/components/common/CompareTable/compareTable.tsx
@@ -15,7 +15,6 @@ import React, { useState } from 'react';
 import SearchQuery, {
   convertToProfOnly,
 } from '../../../modules/SearchQuery/SearchQuery';
-import searchQueryColors from '../../../modules/searchQueryColors/searchQueryColors';
 import searchQueryLabel from '../../../modules/searchQueryLabel/searchQueryLabel';
 import type { RMPInterface } from '../../../pages/api/ratemyprofessorScraper';
 import type {
@@ -288,6 +287,7 @@ type CompareTableProps = {
   grades: { [key: string]: GenericFetchedData<GradesType> };
   rmp: { [key: string]: GenericFetchedData<RMPInterface> };
   removeFromCompare: (arg0: SearchQuery) => void;
+  colorMap: { [key: string]: string };
 };
 
 const CompareTable = ({
@@ -295,6 +295,7 @@ const CompareTable = ({
   grades,
   rmp,
   removeFromCompare,
+  colorMap,
 }: CompareTableProps) => {
   //Table sorting category
   const [orderBy, setOrderBy] = useState<string>('Color');
@@ -388,12 +389,7 @@ const CompareTable = ({
     return 0;
   });
 
-  // Color map for each course in the compare table based on searchQueryColors
-  const colorMap: { [key: string]: string } = {};
-  includedResults.forEach((result, index) => {
-    colorMap[searchQueryLabel(result)] =
-      searchQueryColors[index % searchQueryColors.length];
-  });
+  // Update mappedColors to use the passed colorMap
   const mappedColors = sortedResults.map(
     (result) => colorMap[searchQueryLabel(result)],
   );

--- a/src/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -19,9 +19,7 @@ import React, { useState } from 'react';
 import SearchQuery, {
   convertToProfOnly,
 } from '../../../modules/SearchQuery/SearchQuery';
-import {
-  useRainbowColors,
-} from '../../../modules/searchQueryColors/searchQueryColors';
+import { useRainbowColors } from '../../../modules/searchQueryColors/searchQueryColors';
 import searchQueryEqual from '../../../modules/searchQueryEqual/searchQueryEqual';
 import searchQueryLabel from '../../../modules/searchQueryLabel/searchQueryLabel';
 import type { RMPInterface } from '../../../pages/api/ratemyprofessorScraper';
@@ -506,7 +504,7 @@ const SearchResultsTable = ({
                     }
                     addToCompare={addToCompare}
                     removeFromCompare={removeFromCompare}
-                    color={colorMap[searchQueryLabel(result)]} // Use color from colorMap
+                    color={colorMap[searchQueryLabel(result)]}
                   />
                 ))
               : Array(10)

--- a/src/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -86,7 +86,7 @@ type RowProps = {
   inCompare: boolean;
   addToCompare: (arg0: SearchQuery) => void;
   removeFromCompare: (arg0: SearchQuery) => void;
-  checkboxColor: string;
+  color?: string;
 };
 
 function Row({
@@ -96,7 +96,7 @@ function Row({
   inCompare,
   addToCompare,
   removeFromCompare,
-  checkboxColor,
+  color,
 }: RowProps) {
   const [open, setOpen] = useState(false);
 
@@ -155,15 +155,19 @@ function Row({
                   addToCompare(course);
                 }
               }}
-              sx={{
-                '&.Mui-checked': {
-                  color: checkboxColor,
-                },
-              }}
               disabled={
                 (typeof grades !== 'undefined' && grades.state === 'loading') ||
                 (typeof rmp !== 'undefined' && rmp.state === 'loading')
               }
+              sx={
+                color
+                  ? {
+                      '&.Mui-checked': {
+                        color: color,
+                      },
+                    }
+                  : undefined
+              } // Apply color if defined
             />
           </Tooltip>
         </TableCell>
@@ -300,6 +304,13 @@ const SearchResultsTable = ({
     );
   }
 
+  // Build colorMap based on the 'compare' array
+  const colorMap: { [key: string]: string } = {};
+  compare.forEach((course, index) => {
+    colorMap[searchQueryLabel(course)] =
+      searchQueryColors[index % searchQueryColors.length];
+  });
+
   //Sort
   const sortedResults = includedResults.sort((a, b) => {
     if (orderBy === 'name') {
@@ -424,26 +435,6 @@ const SearchResultsTable = ({
     return 0;
   });
 
-  const isInCompare = (item: SearchQuery) =>
-    compare.some((compItem) => searchQueryEqual(compItem, item));
-
-  let colorIndex = 0;
-  const colorMap: { [key: string]: string } = {};
-
-  includedResults.forEach((result) => {
-    const inCompare = isInCompare(result);
-
-    if (inCompare) {
-      colorMap[searchQueryLabel(result)] =
-        searchQueryColors[colorIndex % searchQueryColors.length];
-      colorIndex++;
-    }
-  });
-
-  const mappedColors = sortedResults.map(
-    (result) => colorMap[searchQueryLabel(result)],
-  );
-
   return (
     //TODO: sticky header
     <>
@@ -507,7 +498,7 @@ const SearchResultsTable = ({
           </TableHead>
           <TableBody>
             {resultsLoading === 'done'
-              ? sortedResults.map((result, index) => (
+              ? sortedResults.map((result) => (
                   <Row
                     key={searchQueryLabel(result)}
                     course={result}
@@ -520,7 +511,7 @@ const SearchResultsTable = ({
                     }
                     addToCompare={addToCompare}
                     removeFromCompare={removeFromCompare}
-                    checkboxColor={mappedColors[index]}
+                    color={colorMap[searchQueryLabel(result)]} // Use color from colorMap
                   />
                 ))
               : Array(10)

--- a/src/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -19,7 +19,9 @@ import React, { useState } from 'react';
 import SearchQuery, {
   convertToProfOnly,
 } from '../../../modules/SearchQuery/SearchQuery';
-import { useRainbowColors } from '../../../modules/searchQueryColors/searchQueryColors';
+import searchQueryColors, {
+  useRainbowColors,
+} from '../../../modules/searchQueryColors/searchQueryColors';
 import searchQueryEqual from '../../../modules/searchQueryEqual/searchQueryEqual';
 import searchQueryLabel from '../../../modules/searchQueryLabel/searchQueryLabel';
 import type { RMPInterface } from '../../../pages/api/ratemyprofessorScraper';
@@ -84,6 +86,7 @@ type RowProps = {
   inCompare: boolean;
   addToCompare: (arg0: SearchQuery) => void;
   removeFromCompare: (arg0: SearchQuery) => void;
+  checkboxColor: string;
 };
 
 function Row({
@@ -93,6 +96,7 @@ function Row({
   inCompare,
   addToCompare,
   removeFromCompare,
+  checkboxColor,
 }: RowProps) {
   const [open, setOpen] = useState(false);
 
@@ -150,6 +154,11 @@ function Row({
                 } else {
                   addToCompare(course);
                 }
+              }}
+              sx={{
+                '&.Mui-checked': {
+                  color: checkboxColor,
+                },
               }}
               disabled={
                 (typeof grades !== 'undefined' && grades.state === 'loading') ||
@@ -415,6 +424,26 @@ const SearchResultsTable = ({
     return 0;
   });
 
+  const isInCompare = (item: SearchQuery) =>
+    compare.some((compItem) => searchQueryEqual(compItem, item));
+
+  let colorIndex = 0;
+  const colorMap: { [key: string]: string } = {};
+
+  includedResults.forEach((result) => {
+    const inCompare = isInCompare(result);
+
+    if (inCompare) {
+      colorMap[searchQueryLabel(result)] =
+        searchQueryColors[colorIndex % searchQueryColors.length];
+      colorIndex++;
+    }
+  });
+
+  const mappedColors = sortedResults.map(
+    (result) => colorMap[searchQueryLabel(result)],
+  );
+
   return (
     //TODO: sticky header
     <>
@@ -478,7 +507,7 @@ const SearchResultsTable = ({
           </TableHead>
           <TableBody>
             {resultsLoading === 'done'
-              ? sortedResults.map((result) => (
+              ? sortedResults.map((result, index) => (
                   <Row
                     key={searchQueryLabel(result)}
                     course={result}
@@ -491,6 +520,7 @@ const SearchResultsTable = ({
                     }
                     addToCompare={addToCompare}
                     removeFromCompare={removeFromCompare}
+                    checkboxColor={mappedColors[index]}
                   />
                 ))
               : Array(10)

--- a/src/components/common/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/common/SearchResultsTable/searchResultsTable.tsx
@@ -19,7 +19,7 @@ import React, { useState } from 'react';
 import SearchQuery, {
   convertToProfOnly,
 } from '../../../modules/SearchQuery/SearchQuery';
-import searchQueryColors, {
+import {
   useRainbowColors,
 } from '../../../modules/searchQueryColors/searchQueryColors';
 import searchQueryEqual from '../../../modules/searchQueryEqual/searchQueryEqual';
@@ -256,6 +256,7 @@ type SearchResultsTableProps = {
   compare: SearchQuery[];
   addToCompare: (arg0: SearchQuery) => void;
   removeFromCompare: (arg0: SearchQuery) => void;
+  colorMap: { [key: string]: string };
 };
 
 const SearchResultsTable = ({
@@ -266,6 +267,7 @@ const SearchResultsTable = ({
   compare,
   addToCompare,
   removeFromCompare,
+  colorMap,
 }: SearchResultsTableProps) => {
   //Table sorting category
   const [orderBy, setOrderBy] = useState<'name' | 'gpa' | 'rating'>('name');
@@ -303,13 +305,6 @@ const SearchResultsTable = ({
       </div>
     );
   }
-
-  // Build colorMap based on the 'compare' array
-  const colorMap: { [key: string]: string } = {};
-  compare.forEach((course, index) => {
-    colorMap[searchQueryLabel(course)] =
-      searchQueryColors[index % searchQueryColors.length];
-  });
 
   //Sort
   const sortedResults = includedResults.sort((a, b) => {

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -233,7 +233,8 @@ function fetchRmpData(
 function createColorMap(courses: SearchQuery[]): { [key: string]: string } {
   const colorMap: { [key: string]: string } = {};
   courses.forEach((course, index) => {
-    colorMap[searchQueryLabel(course)] = searchQueryColors[index % searchQueryColors.length];
+    colorMap[searchQueryLabel(course)] =
+      searchQueryColors[index % searchQueryColors.length];
   });
   return colorMap;
 }
@@ -732,7 +733,7 @@ export const Dashboard: NextPage = () => {
         grades={compareGrades}
         rmp={compareRmp}
         removeFromCompare={removeFromCompare}
-        colorMap={colorMap}  // Add this prop
+        colorMap={colorMap}
       />,
     );
     contentComponent = (
@@ -758,7 +759,7 @@ export const Dashboard: NextPage = () => {
               compare={compare}
               addToCompare={addToCompare}
               removeFromCompare={removeFromCompare}
-              colorMap={colorMap}  // Add this prop
+              colorMap={colorMap}
             />
           </Grid>
           <Grid item xs={false} sm={6} md={6} className="w-full">

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -21,6 +21,7 @@ import fetchWithCache, {
 } from '../../modules/fetchWithCache';
 import type SearchQuery from '../../modules/SearchQuery/SearchQuery';
 import { convertToProfOnly } from '../../modules/SearchQuery/SearchQuery';
+import searchQueryColors from '../../modules/searchQueryColors/searchQueryColors';
 import searchQueryEqual from '../../modules/searchQueryEqual/searchQueryEqual';
 import searchQueryLabel from '../../modules/searchQueryLabel/searchQueryLabel';
 import type { GradesData } from '../../pages/api/grades';
@@ -226,6 +227,15 @@ function fetchRmpData(
     }
     return response.data;
   });
+}
+
+// Add this utility function after the existing type definitions
+function createColorMap(courses: SearchQuery[]): { [key: string]: string } {
+  const colorMap: { [key: string]: string } = {};
+  courses.forEach((course, index) => {
+    colorMap[searchQueryLabel(course)] = searchQueryColors[index % searchQueryColors.length];
+  });
+  return colorMap;
 }
 
 export const Dashboard: NextPage = () => {
@@ -679,6 +689,9 @@ export const Dashboard: NextPage = () => {
     }
   }
 
+  // Add this after the compare state declaration
+  const colorMap = createColorMap(compare);
+
   //Main content: loading, error, or normal
   let contentComponent;
 
@@ -719,6 +732,7 @@ export const Dashboard: NextPage = () => {
         grades={compareGrades}
         rmp={compareRmp}
         removeFromCompare={removeFromCompare}
+        colorMap={colorMap}  // Add this prop
       />,
     );
     contentComponent = (
@@ -744,6 +758,7 @@ export const Dashboard: NextPage = () => {
               compare={compare}
               addToCompare={addToCompare}
               removeFromCompare={removeFromCompare}
+              colorMap={colorMap}  // Add this prop
             />
           </Grid>
           <Grid item xs={false} sm={6} md={6} className="w-full">


### PR DESCRIPTION
# Overview

This pull request enhances the user experience by ensuring that the compare colors are consistently displayed on the left-hand side (LHS) checkboxes in the search results, matching the colors used in the right-hand side (RHS) compare table. This visual alignment makes it easier for users to correlate items between the search results and the compare view.

# What Changed

- **SearchResultsTable.tsx:**
  - Imported `searchQueryColors` to access the array of colors used for comparison items.
  - Calculated `colorMap` to map each search result to a specific color based on its index.
  - Passed the corresponding color to each `Row` component as a new `color` prop.

- **`Row` Component in `SearchResultsTable.tsx`:**
  - Updated the `RowProps` type to include the new `color` prop.
  - Applied the passed `color` to the compare checkbox using the `sx` prop, ensuring the checkbox on the LHS matches the color in the compare table.

- **Consistency with Compare Table:**
  - Ensured that both the search results checkboxes and the compare table checkboxes use the same color logic, derived from `searchQueryColors`.

# Other Notes

- **Future Improvements:**
  - Handling edge cases where the number of items exceeds the number of predefined colors by generating additional colors dynamically.
