### PR TITLE
Fix duplicate GitHub button

### DIFF
--- a/src/components/common/GitHubButton/gitHubButton.tsx
+++ b/src/components/common/GitHubButton/gitHubButton.tsx
@@ -1,11 +1,8 @@
 import GitHub from '@mui/icons-material/GitHub';
-import { Card, IconButton, Tooltip, useMediaQuery } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import React from 'react';
 
 export default function GitHubButton() {
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const cardElevation = prefersDarkMode ? 3 : 1;
-
   const showGitInfo =
     typeof process.env.NEXT_PUBLIC_VERCEL_ENV !== 'undefined' &&
     process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' &&
@@ -17,24 +14,20 @@ export default function GitHubButton() {
   }
 
   return (
-    <Card
-      className="w-fit h-fit bg-light fixed bottom-2 right-2 rounded-full"
-      elevation={cardElevation}
-    >
-      <Tooltip title="Open GitHub commit for this instance">
-        <a
-          href={
-            'https://github.com/UTDNebula/utd-trends/commit/' +
-            process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
-          }
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <IconButton size="large">
-            <GitHub className="fill-dark text-3xl" />
-          </IconButton>
-        </a>
-      </Tooltip>
-    </Card>
+    <Tooltip title="Open GitHub commit for this instance">
+      <a
+        href={
+          'https://github.com/UTDNebula/utd-trends/commit/' +
+          process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
+        }
+        rel="noreferrer"
+        target="_blank"
+        className="w-fit h-fit bg-white fixed bottom-2 right-2 rounded-full"
+      >
+        <IconButton size="large">
+          <GitHub className="fill-black text-3xl" />
+        </IconButton>
+      </a>
+    </Tooltip>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import '../styles/globals.css';
 
-import GitHub from '@mui/icons-material/GitHub';
-import { Card, IconButton, Tooltip, useMediaQuery } from '@mui/material';
+import { useMediaQuery } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { Analytics } from '@vercel/analytics/react';
@@ -99,12 +98,6 @@ function MyApp({ Component, pageProps }: AppProps) {
     },
   });
 
-  const showGitInfo =
-    typeof process.env.NEXT_PUBLIC_VERCEL_ENV !== 'undefined' &&
-    process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' &&
-    typeof process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA !== 'undefined' &&
-    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA !== '';
-
   const router = useRouter();
 
   return (
@@ -148,26 +141,6 @@ function MyApp({ Component, pageProps }: AppProps) {
       </ThemeProvider>
       <Analytics />
       <SpeedInsights route={router.pathname} />
-      {showGitInfo && (
-        <>
-          <Card className="w-fit h-fit bg-light fixed bottom-2 right-2 rounded-full">
-            <Tooltip title="Open GitHub commit for this instance">
-              <a
-                href={
-                  'https://github.com/UTDNebula/utd-trends/commit/' +
-                  process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
-                }
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <IconButton size="large">
-                  <GitHub className="fill-dark text-3xl" />
-                </IconButton>
-              </a>
-            </Tooltip>
-          </Card>
-        </>
-      )}
     </>
   );
 }


### PR DESCRIPTION
## Overview

The GitHub button appears only on development deployments and links to the GitHub commit the deployment was made off of.

Realized there were 2 instances of the GitHub button, overlapping each other.

## What Changed

Removed the GitHub button in `_app` and kept the component.