### PR TITLE
RHS compare indicators and resizing when no semesters selected

### DIFF
--- a/src/components/common/SingleProfInfo/singleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/singleProfInfo.tsx
@@ -116,11 +116,20 @@ function SingleProfInfo({ rmp }: Props) {
   return (
     <Grid container spacing={2} className="p-4">
       <Grid size={6}>
-        <p className="text-xl font-bold">{rmp.data.avgRating}</p>
+        <p className="text-xl font-bold">
+          {typeof rmp.data.avgRating !== undefined && rmp.data.avgRating > 0
+            ? rmp.data.avgRating
+            : 'N/A'}
+        </p>
         <p>Professor rating</p>
       </Grid>
       <Grid size={6}>
-        <p className="text-xl font-bold">{rmp.data.avgDifficulty}</p>
+        <p className="text-xl font-bold">
+          {typeof rmp.data.avgDifficulty !== undefined &&
+          rmp.data.avgDifficulty > 0
+            ? rmp.data.avgDifficulty
+            : 'N/A'}
+        </p>
         <p>Difficulty</p>
       </Grid>
       <Grid size={6}>
@@ -131,7 +140,10 @@ function SingleProfInfo({ rmp }: Props) {
       </Grid>
       <Grid size={6}>
         <p className="text-xl font-bold">
-          {rmp.data.wouldTakeAgainPercent.toFixed(0) + '%'}
+          {typeof rmp.data.wouldTakeAgainPercent !== undefined &&
+          rmp.data.wouldTakeAgainPercent > 0
+            ? rmp.data.wouldTakeAgainPercent.toFixed(0) + '%'
+            : 'N/A'}
         </p>
         <p>Would take again</p>
       </Grid>

--- a/src/components/common/SingleProfInfo/singleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/singleProfInfo.tsx
@@ -117,18 +117,13 @@ function SingleProfInfo({ rmp }: Props) {
     <Grid container spacing={2} className="p-4">
       <Grid size={6}>
         <p className="text-xl font-bold">
-          {typeof rmp.data.avgRating !== undefined && rmp.data.avgRating > 0
-            ? rmp.data.avgRating
-            : 'N/A'}
+          {rmp.data.avgRating > 0 ? rmp.data.avgRating : 'N/A'}
         </p>
         <p>Professor rating</p>
       </Grid>
       <Grid size={6}>
         <p className="text-xl font-bold">
-          {typeof rmp.data.avgDifficulty !== undefined &&
-          rmp.data.avgDifficulty > 0
-            ? rmp.data.avgDifficulty
-            : 'N/A'}
+          {rmp.data.avgDifficulty > 0 ? rmp.data.avgDifficulty : 'N/A'}
         </p>
         <p>Difficulty</p>
       </Grid>
@@ -140,8 +135,7 @@ function SingleProfInfo({ rmp }: Props) {
       </Grid>
       <Grid size={6}>
         <p className="text-xl font-bold">
-          {typeof rmp.data.wouldTakeAgainPercent !== undefined &&
-          rmp.data.wouldTakeAgainPercent > 0
+          {rmp.data.wouldTakeAgainPercent > 0
             ? rmp.data.wouldTakeAgainPercent.toFixed(0) + '%'
             : 'N/A'}
         </p>

--- a/src/components/compare/CompareTable/compareTable.tsx
+++ b/src/components/compare/CompareTable/compareTable.tsx
@@ -141,7 +141,7 @@ function GradeOrRmpRow<T>({
                 <Typography className="text-base">{loadingFiller}</Typography>
               </Skeleton>
             )) ||
-            (value.state === 'done' &&
+            ((value.state === 'done' && getValue(value.data) !== -1) ?
               (name !== 'GPA'
                 ? (value.data as RMPInterface).numRatings > 0
                 : true) && ( // do not display RMP data (non-GPA data) if there are no reviews
@@ -165,7 +165,7 @@ function GradeOrRmpRow<T>({
                     {formatValue(getValue(value.data))}
                   </Typography>
                 </Tooltip>
-              )) ||
+              ) : <Typography className="text-base opacity-0">0.00</Typography>) ||
             null}
         </TableCell>
       ))}

--- a/src/components/compare/CompareTable/compareTable.tsx
+++ b/src/components/compare/CompareTable/compareTable.tsx
@@ -141,7 +141,7 @@ function GradeOrRmpRow<T>({
                 <Typography className="text-base">{loadingFiller}</Typography>
               </Skeleton>
             )) ||
-            ((value.state === 'done' && getValue(value.data) !== -1) ?
+            (value.state === 'done' && getValue(value.data) !== -1 ? (
               (name !== 'GPA'
                 ? (value.data as RMPInterface).numRatings > 0
                 : true) && ( // do not display RMP data (non-GPA data) if there are no reviews
@@ -165,7 +165,10 @@ function GradeOrRmpRow<T>({
                     {formatValue(getValue(value.data))}
                   </Typography>
                 </Tooltip>
-              ) : <Typography className="text-base opacity-0">0.00</Typography>) ||
+              )
+            ) : (
+              <Typography className="text-base opacity-0">0.00</Typography>
+            )) ||
             null}
         </TableCell>
       ))}


### PR DESCRIPTION
## Overview
Resolves #304 

## What Changed
Re-adds check for -1 GPA (for some reason it was showing -1 as the GPA again on some professors). Adds empty space with same dimensions in the compare table when there is no GPA is -1, which minimizes jumping.

## Other Notes
The bar graph still moves around a bit because the labels disappear and the graph height expands. If we wanted we could keep the labels visible to avoid this, but it seems like that could be confusing and it would get rid of the empty state text.