### PR TITLE
Fix next warning

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ['profiles.utdallas.edu'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'profiles.utdallas.edu',
+        port: '',
+        pathname: '/**',
+        search: '',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## Overview

This warning pops up on `npm run start`:

⚠ The "images.domains" configuration is deprecated. Please use "images.remotePatterns" configuration instead.

## What Changed

Updated with these docs: https://nextjs.org/docs/pages/api-reference/components/image#remotepatterns
