### PR TITLE
280 feature request indicate most recent semester taught

### DIFF
--- a/src/components/overview/ProfessorOverview/professorOverview.tsx
+++ b/src/components/overview/ProfessorOverview/professorOverview.tsx
@@ -18,7 +18,7 @@ import type { GenericFetchedData, GradesType } from '@/pages/dashboard/index';
 
 const fallbackSrc = 'https://profiles.utdallas.edu/img/default.png';
 
-interface ProfessorInterface {
+export interface ProfessorInterface {
   _id: string;
   email: string;
   first_name: string;

--- a/src/components/search/Filters/filters.tsx
+++ b/src/components/search/Filters/filters.tsx
@@ -24,6 +24,40 @@ interface FiltersProps {
   addChosenSessions: (arg0: (arg0: string[]) => string[]) => void;
 }
 
+/** Returns the current semester based on today's month and year */
+export function getCurrentSemester() {
+  // get current month and year
+  const today = new Date();
+  const mm = today.getMonth() + 1; // January is 1
+  const yyyy = today.getFullYear();
+
+  let season = 'F';
+  if (mm <= 5)
+    // jan - may
+    season = 'S';
+  else season = 'F';
+
+  return {
+    season: season,
+    yyyy: yyyy,
+  };
+}
+
+/** returns the season and yyyy of the previous long semester */
+export function getLastLongSemester(season: string, yyyy: number) {
+  if (season === 'S') {
+    // then the previous semester is last year's Fall
+    yyyy = yyyy - 1;
+    season = 'F';
+  } // then the previous long-semester is this year's Spring
+  else season = 'S';
+
+  return {
+    season: season,
+    yyyy: yyyy,
+  };
+}
+
 /** A comparator function used when sorting semesters by name. Returns -1 if semester 'a' is more older than semester 'b'. */
 export function compareSemesters(a: string, b: string) {
   const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
@@ -88,25 +122,10 @@ const Filters = ({
 
   function getRecentSemesters() {
     let recentSemesters: string[] = [];
-    // get current month and year
-    const today = new Date();
-    const mm = today.getMonth() + 1; // January is 1
-    let yyyy = today.getFullYear();
-
-    let season = 'F';
-    if (mm <= 5)
-      // jan - may
-      season = 'S';
-    else season = 'F';
-
+    let { season, yyyy } = getCurrentSemester();
     // generate recent semesters dynamically from the current day
     for (let i = MAX_NUM_RECENT_SEMESTERS; i >= 1; i--) {
-      if (season === 'S') {
-        // then the previous semester is last year's Fall
-        yyyy = yyyy - 1;
-        season = 'F';
-      } // then the previous long-semester is this year's Spring
-      else season = 'S';
+      ({ season, yyyy } = getLastLongSemester(season, yyyy));
 
       recentSemesters.push(yyyy.toString().substring(2) + season);
     }

--- a/src/components/search/Filters/filters.tsx
+++ b/src/components/search/Filters/filters.tsx
@@ -39,13 +39,21 @@ export function compareSemesters(a: string, b: string) {
   } else return x;
 }
 
-export function displayAcademicSessionName(id: string) {
-  return (
-    '20' +
-    id.slice(0, 2) +
-    ' ' +
-    { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
-  );
+export function displayAcademicSessionName(id: string, yearFirst: boolean) {
+  if (yearFirst)
+    return (
+      '20' +
+      id.slice(0, 2) +
+      ' ' +
+      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
+    );
+  else
+    return (
+      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)] +
+      ' ' +
+      '20' +
+      id.slice(0, 2)
+    );
 }
 
 /**
@@ -310,7 +318,9 @@ const Filters = ({
                 value={session}
               >
                 <Checkbox checked={chosenSessions.includes(session)} />
-                <ListItemText primary={displayAcademicSessionName(session)} />
+                <ListItemText
+                  primary={displayAcademicSessionName(session, true)}
+                />
               </MenuItem>
             ))}
           </Select>

--- a/src/components/search/Filters/filters.tsx
+++ b/src/components/search/Filters/filters.tsx
@@ -13,6 +13,12 @@ import React, { useEffect, useState } from 'react';
 
 import Rating from '@/components/common/Rating/rating';
 import gpaToLetterGrade from '@/modules/gpaToLetterGrade/gpaToLetterGrade';
+import {
+  compareSemesters,
+  displayAcademicSessionName,
+  getCurrentSemester,
+  getLastLongSemester,
+} from '@/modules/semesters/semesters';
 
 const minGPAs = ['3.67', '3.33', '3', '2.67', '2.33', '2'];
 const minRatings = ['4.5', '4', '3.5', '3', '2.5', '2', '1.5', '1', '0.5'];
@@ -22,72 +28,6 @@ interface FiltersProps {
   academicSessions: string[];
   chosenSessions: string[];
   addChosenSessions: (arg0: (arg0: string[]) => string[]) => void;
-}
-
-/** Returns the current semester based on today's month and year */
-export function getCurrentSemester() {
-  // get current month and year
-  const today = new Date();
-  const mm = today.getMonth() + 1; // January is 1
-  const yyyy = today.getFullYear();
-
-  let season = 'F';
-  if (mm <= 5)
-    // jan - may
-    season = 'S';
-  else season = 'F';
-
-  return {
-    season: season,
-    yyyy: yyyy,
-  };
-}
-
-/** returns the season and yyyy of the previous long semester */
-export function getLastLongSemester(season: string, yyyy: number) {
-  if (season === 'S') {
-    // then the previous semester is last year's Fall
-    yyyy = yyyy - 1;
-    season = 'F';
-  } // then the previous long-semester is this year's Spring
-  else season = 'S';
-
-  return {
-    season: season,
-    yyyy: yyyy,
-  };
-}
-
-/** A comparator function used when sorting semesters by name. Returns -1 if semester 'a' is more older than semester 'b'. */
-export function compareSemesters(a: string, b: string) {
-  const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
-  if (x == 0) {
-    const a_char = a[2];
-    const b_char = b[2];
-    // a_char and b_char cannot both be the same semester because x == 0
-    if (a_char == 'S') return -1;
-    if (a_char == 'U' && b_char == 'S') return 1;
-    if (a_char == 'U' && b_char == 'F') return -1;
-    if (a_char == 'F') return 1;
-    return 0;
-  } else return x;
-}
-
-export function displayAcademicSessionName(id: string, yearFirst: boolean) {
-  if (yearFirst)
-    return (
-      '20' +
-      id.slice(0, 2) +
-      ' ' +
-      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
-    );
-  else
-    return (
-      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)] +
-      ' ' +
-      '20' +
-      id.slice(0, 2)
-    );
 }
 
 /**

--- a/src/components/search/Filters/filters.tsx
+++ b/src/components/search/Filters/filters.tsx
@@ -24,6 +24,30 @@ interface FiltersProps {
   addChosenSessions: (arg0: (arg0: string[]) => string[]) => void;
 }
 
+  /** A comparator function used when sorting semesters by name. Returns -1 if semester 'a' is more older than semester 'b'. */
+  export function compareSemesters(a: string, b: string) {
+    const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
+    if (x == 0) {
+      const a_char = a[2];
+      const b_char = b[2];
+      // a_char and b_char cannot both be the same semester because x == 0
+      if (a_char == 'S') return -1;
+      if (a_char == 'U' && b_char == 'S') return 1;
+      if (a_char == 'U' && b_char == 'F') return -1;
+      if (a_char == 'F') return 1;
+      return 0;
+    } else return x;
+  }
+
+  export function displayAcademicSessionName(id: string) {
+    return (
+      '20' +
+      id.slice(0, 2) +
+      ' ' +
+      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
+    );
+  }
+
 /**
  * This component returns a set of filters with which to sort results.
  */
@@ -107,29 +131,6 @@ const Filters = ({
         { shallow: true },
       );
     }
-  }
-
-  function displayAcademicSessionName(id: string) {
-    return (
-      '20' +
-      id.slice(0, 2) +
-      ' ' +
-      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
-    );
-  }
-
-  function compareSemesters(a: string, b: string) {
-    const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
-    if (x == 0) {
-      const a_char = a[2];
-      const b_char = b[2];
-      // a_char and b_char cannot both be the same semester because x == 0
-      if (a_char == 'S') return -1;
-      if (a_char == 'U' && b_char == 'S') return 1;
-      if (a_char == 'U' && b_char == 'F') return -1;
-      if (a_char == 'F') return 1;
-      return 0;
-    } else return x;
   }
 
   return (

--- a/src/components/search/Filters/filters.tsx
+++ b/src/components/search/Filters/filters.tsx
@@ -24,29 +24,29 @@ interface FiltersProps {
   addChosenSessions: (arg0: (arg0: string[]) => string[]) => void;
 }
 
-  /** A comparator function used when sorting semesters by name. Returns -1 if semester 'a' is more older than semester 'b'. */
-  export function compareSemesters(a: string, b: string) {
-    const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
-    if (x == 0) {
-      const a_char = a[2];
-      const b_char = b[2];
-      // a_char and b_char cannot both be the same semester because x == 0
-      if (a_char == 'S') return -1;
-      if (a_char == 'U' && b_char == 'S') return 1;
-      if (a_char == 'U' && b_char == 'F') return -1;
-      if (a_char == 'F') return 1;
-      return 0;
-    } else return x;
-  }
+/** A comparator function used when sorting semesters by name. Returns -1 if semester 'a' is more older than semester 'b'. */
+export function compareSemesters(a: string, b: string) {
+  const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
+  if (x == 0) {
+    const a_char = a[2];
+    const b_char = b[2];
+    // a_char and b_char cannot both be the same semester because x == 0
+    if (a_char == 'S') return -1;
+    if (a_char == 'U' && b_char == 'S') return 1;
+    if (a_char == 'U' && b_char == 'F') return -1;
+    if (a_char == 'F') return 1;
+    return 0;
+  } else return x;
+}
 
-  export function displayAcademicSessionName(id: string) {
-    return (
-      '20' +
-      id.slice(0, 2) +
-      ' ' +
-      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
-    );
-  }
+export function displayAcademicSessionName(id: string) {
+  return (
+    '20' +
+    id.slice(0, 2) +
+    ' ' +
+    { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
+  );
+}
 
 /**
  * This component returns a set of filters with which to sort results.

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -253,7 +253,9 @@ function Row({
               </Typography>
             </Tooltip>
             {((typeof grades === 'undefined' || grades.state === 'error') && (
-              <></>
+              <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-24 block bg-gray-100">
+                New Professor!
+              </Typography>
             )) ||
               (grades.state === 'loading' && (
                 <Skeleton
@@ -272,7 +274,7 @@ function Row({
                   placement="top"
                 >
                   <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-8 block bg-gray-100">
-                    {most_recent_semester}
+                     {most_recent_semester}
                   </Typography>
                 </Tooltip>
               )) ||

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -253,9 +253,16 @@ function Row({
               </Typography>
             </Tooltip>
             {((typeof grades === 'undefined' || grades.state === 'error') && (
-              <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-24 block bg-gray-100">
-                New Professor!
-              </Typography>
+              <Tooltip
+                title={
+                  'The professor is teaching this course for the first time'
+                }
+                placement="top"
+              >
+                <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-10 block bg-gray-100">
+                  New
+                </Typography>
+              </Tooltip>
             )) ||
               (grades.state === 'loading' && (
                 <Skeleton
@@ -274,7 +281,7 @@ function Row({
                   placement="top"
                 >
                   <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-8 block bg-gray-100">
-                     {most_recent_semester}
+                    {most_recent_semester}
                   </Typography>
                 </Tooltip>
               )) ||

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -260,7 +260,7 @@ function Row({
                   }
                   placement="top"
                 >
-                  <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-8 block bg-cornflower-50">
+                  <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-8 block bg-gray-100">
                     {most_recent_semester}
                   </Typography>
                 </Tooltip>

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -116,6 +116,17 @@ function Row({
     most_recent_semester_from_grades: string,
   ): string {
     let { season, yyyy } = getCurrentSemester();
+    console.log('hi', sections);
+    if (
+      typeof sections !== 'undefined' &&
+      sections.state === 'done' &&
+      typeof course.profFirst === 'undefined' &&
+      typeof course.profLast === 'undefined'
+    ) {
+      return sections.data.sort((a, b) =>
+        compareSemesters(b.academic_session.name, a.academic_session.name),
+      )[0].academic_session.name;
+    }
     if (
       typeof sections !== 'undefined' &&
       typeof professor !== 'undefined' &&

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -146,6 +146,11 @@ function Row({
     return most_recent_semester_from_grades;
   }
 
+  let most_recent_semester =
+    grades.state === 'done'
+      ? getMostRecentSemester(grades.data.most_recent_semester)
+      : '';
+
   return (
     <>
       <TableRow
@@ -251,15 +256,12 @@ function Row({
                 <Tooltip
                   title={
                     'Last taught in: ' +
-                    displayAcademicSessionName(
-                      getMostRecentSemester(grades.data.most_recent_semester),
-                      false,
-                    )
+                    displayAcademicSessionName(most_recent_semester, false)
                   }
                   placement="top"
                 >
                   <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-8 block bg-cornflower-50">
-                    {getMostRecentSemester(grades.data.most_recent_semester)}
+                    {most_recent_semester}
                   </Typography>
                 </Tooltip>
               )) ||

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -20,6 +20,7 @@ import Rating from '@/components/common/Rating/rating';
 import SingleGradesInfo from '@/components/common/SingleGradesInfo/singleGradesInfo';
 import SingleProfInfo from '@/components/common/SingleProfInfo/singleProfInfo';
 import TableSortLabel from '@/components/common/TableSortLabel/tableSortLabel';
+import { displayAcademicSessionName } from '@/components/search/Filters/filters';
 import { useRainbowColors } from '@/modules/colors/colors';
 import gpaToLetterGrade from '@/modules/gpaToLetterGrade/gpaToLetterGrade';
 import {
@@ -156,38 +157,65 @@ function Row({
           </div>
         </TableCell>
         <TableCell component="th" scope="row" className="w-full border-b-0">
-          <Tooltip
-            title={
-              typeof course.profFirst !== 'undefined' &&
-              typeof course.profLast !== 'undefined' &&
-              (rmp !== undefined &&
-              rmp.state === 'done' &&
-              rmp.data.teacherRatingTags.length > 0
-                ? 'Tags: ' +
-                  rmp.data.teacherRatingTags
-                    .sort((a, b) => b.tagCount - a.tagCount)
-                    .slice(0, 3)
-                    .map((tag) => tag.tagName)
-                    .join(', ')
-                : 'No Tags Available')
-            }
-            placement="top"
-          >
-            <Typography
-              onClick={
-                (e) => e.stopPropagation() // prevents opening/closing the card when clicking on the text
+          <div className="flex items-center gap-1">
+            <Tooltip
+              title={
+                typeof course.profFirst !== 'undefined' &&
+                typeof course.profLast !== 'undefined' &&
+                (rmp !== undefined &&
+                rmp.state === 'done' &&
+                rmp.data.teacherRatingTags.length > 0
+                  ? 'Tags: ' +
+                    rmp.data.teacherRatingTags
+                      .sort((a, b) => b.tagCount - a.tagCount)
+                      .slice(0, 3)
+                      .map((tag) => tag.tagName)
+                      .join(', ')
+                  : 'No Tags Available')
               }
-              className="leading-tight text-lg text-gray-600 dark:text-gray-200 cursor-text w-fit"
+              placement="top"
             >
-              {searchQueryLabel(course) +
-                ((typeof course.profFirst === 'undefined' &&
-                  typeof course.profLast === 'undefined') ||
-                (typeof course.prefix === 'undefined' &&
-                  typeof course.number === 'undefined')
-                  ? ' (Overall)'
-                  : '')}
-            </Typography>
-          </Tooltip>
+              <Typography
+                onClick={
+                  (e) => e.stopPropagation() // prevents opening/closing the card when clicking on the text
+                }
+                className="leading-tight text-lg text-gray-600 dark:text-gray-200 cursor-text w-fit"
+              >
+                {searchQueryLabel(course) +
+                  ((typeof course.profFirst === 'undefined' &&
+                    typeof course.profLast === 'undefined') ||
+                  (typeof course.prefix === 'undefined' &&
+                    typeof course.number === 'undefined')
+                    ? ' (Overall)'
+                    : '')}
+              </Typography>
+            </Tooltip>
+            {((typeof grades === 'undefined' || grades.state === 'error') && (
+              <></>
+            )) ||
+              (grades.state === 'loading' && (
+                <Skeleton
+                  variant="rounded"
+                  className="rounded-full px-1 py-1 ml-1 w-8 block"
+                >
+                  <Typography className="text-xs w-6">U25</Typography>
+                </Skeleton>
+              )) ||
+              (grades.state === 'done' && (
+                <Tooltip
+                  title={
+                    'Last taught in: ' +
+                    displayAcademicSessionName(grades.data.most_recent_semester)
+                  }
+                  placement="top"
+                >
+                  <Typography className="text-xs text-black text-center rounded-full px-1 py-1 ml-1 w-8 block bg-cornflower-50">
+                    {grades.data.most_recent_semester}
+                  </Typography>
+                </Tooltip>
+              )) ||
+              null}
+          </div>
         </TableCell>
         <TableCell align="center" className="border-b-0">
           {((typeof grades === 'undefined' || grades.state === 'error') && (

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -205,7 +205,10 @@ function Row({
                 <Tooltip
                   title={
                     'Last taught in: ' +
-                    displayAcademicSessionName(grades.data.most_recent_semester)
+                    displayAcademicSessionName(
+                      grades.data.most_recent_semester,
+                      false,
+                    )
                   }
                   placement="top"
                 >

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -21,12 +21,6 @@ import SingleGradesInfo from '@/components/common/SingleGradesInfo/singleGradesI
 import SingleProfInfo from '@/components/common/SingleProfInfo/singleProfInfo';
 import TableSortLabel from '@/components/common/TableSortLabel/tableSortLabel';
 import type { ProfessorInterface } from '@/components/overview/ProfessorOverview/professorOverview';
-import {
-  compareSemesters,
-  displayAcademicSessionName,
-  getCurrentSemester,
-  getLastLongSemester,
-} from '@/components/search/Filters/filters';
 import { useRainbowColors } from '@/modules/colors/colors';
 import gpaToLetterGrade from '@/modules/gpaToLetterGrade/gpaToLetterGrade';
 import {
@@ -36,6 +30,12 @@ import {
   searchQueryEqual,
   searchQueryLabel,
 } from '@/modules/SearchQuery/SearchQuery';
+import {
+  compareSemesters,
+  displayAcademicSessionName,
+  getCurrentSemester,
+  getLastLongSemester,
+} from '@/modules/semesters/semesters';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
 import type { SectionData } from '@/pages/api/section';
 import type { GenericFetchedData, GradesType } from '@/pages/dashboard/index';

--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -146,7 +146,7 @@ function Row({
     return most_recent_semester_from_grades;
   }
 
-  let most_recent_semester =
+  const most_recent_semester =
     grades.state === 'done'
       ? getMostRecentSemester(grades.data.most_recent_semester)
       : '';

--- a/src/modules/SearchQuery/SearchQuery.tsx
+++ b/src/modules/SearchQuery/SearchQuery.tsx
@@ -11,6 +11,11 @@ export type Professor = {
   profLast: string;
 };
 
+export type Course = {
+  prefix: string;
+  number: string;
+};
+
 export function convertToProfOnly(
   searchQuery: SearchQuery,
 ): Professor | Record<string, never> {
@@ -20,6 +25,18 @@ export function convertToProfOnly(
   return {
     profFirst: searchQuery.profFirst as string,
     profLast: searchQuery.profLast as string,
+  };
+}
+
+export function convertToCourseOnly(
+  searchQuery: SearchQuery,
+): Course | Record<string, never> {
+  if (!('prefix' in searchQuery && 'number' in searchQuery)) {
+    return {};
+  }
+  return {
+    prefix: searchQuery.prefix as string,
+    number: searchQuery.number as string,
   };
 }
 

--- a/src/modules/semesters/semesters.tsx
+++ b/src/modules/semesters/semesters.tsx
@@ -1,0 +1,65 @@
+/** Returns the current semester based on today's month and year */
+export function getCurrentSemester() {
+  // get current month and year
+  const today = new Date();
+  const mm = today.getMonth() + 1; // January is 1
+  const yyyy = today.getFullYear();
+
+  let season = 'F';
+  if (mm <= 5)
+    // jan - may
+    season = 'S';
+  else season = 'F';
+
+  return {
+    season: season,
+    yyyy: yyyy,
+  };
+}
+
+/** returns the season and yyyy of the previous long semester */
+export function getLastLongSemester(season: string, yyyy: number) {
+  if (season === 'S') {
+    // then the previous semester is last year's Fall
+    yyyy = yyyy - 1;
+    season = 'F';
+  } // then the previous long-semester is this year's Spring
+  else season = 'S';
+
+  return {
+    season: season,
+    yyyy: yyyy,
+  };
+}
+
+/** A comparator function used when sorting semesters by name. Returns -1 if semester 'a' is more older than semester 'b'. */
+export function compareSemesters(a: string, b: string) {
+  const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
+  if (x == 0) {
+    const a_char = a[2];
+    const b_char = b[2];
+    // a_char and b_char cannot both be the same semester because x == 0
+    if (a_char == 'S') return -1;
+    if (a_char == 'U' && b_char == 'S') return 1;
+    if (a_char == 'U' && b_char == 'F') return -1;
+    if (a_char == 'F') return 1;
+    return 0;
+  } else return x;
+}
+
+export function displayAcademicSessionName(id: string, yearFirst: boolean) {
+  if (yearFirst)
+    return (
+      '20' +
+      id.slice(0, 2) +
+      ' ' +
+      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)]
+    );
+  else
+    return (
+      { U: 'Summer', F: 'Fall', S: 'Spring' }[id.slice(2)] +
+      ' ' +
+      '20' +
+      id.slice(0, 2)
+    );
+}

--- a/src/pages/api/section.ts
+++ b/src/pages/api/section.ts
@@ -11,13 +11,13 @@ export type SectionData = {
   _id: string;
   section_number: string;
   course_reference: string;
-  section_corequisites: any; //todo
+  section_corequisites: unknown; //todo
   academic_session: AcademicSession;
   professors: Array<string>;
-  teaching_assistants: Array<any>; //todo
+  teaching_assistants: Array<unknown>; //todo
   internal_class_number: string;
   instruction_mode: string;
-  meetings: Array<any>; //todo
+  meetings: Array<unknown>; //todo
   core_flags: Array<string>;
   syllabus_uri: string;
   grade_distribution: Array<number>;

--- a/src/pages/api/section.ts
+++ b/src/pages/api/section.ts
@@ -1,0 +1,73 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type AcademicSession = {
+  name: string;
+  start_date: string;
+  end_date: string;
+};
+
+export type SectionData = {
+  _id: string;
+  section_number: string;
+  course_reference: string;
+  section_corequisites: any; //todo
+  academic_session: AcademicSession;
+  professors: Array<string>;
+  teaching_assistants: Array<any>; //todo
+  internal_class_number: string;
+  instruction_mode: string;
+  meetings: Array<any>; //todo
+  core_flags: Array<string>;
+  syllabus_uri: string;
+  grade_distribution: Array<number>;
+  attributes: object;
+};
+
+type Data = {
+  message: string;
+  data?: SectionData;
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>,
+) {
+  const API_KEY = process.env.REACT_APP_NEBULA_API_KEY;
+  if (typeof API_KEY !== 'string') {
+    res.status(500).json({ message: 'API key is undefined' });
+    return;
+  }
+  const sectionID = req.query.sectionID;
+  if (typeof sectionID !== 'string') {
+    res.status(400).json({ message: 'Incorrect query present' });
+    return;
+  }
+  const headers = {
+    'x-api-key': API_KEY,
+    Accept: 'application/json',
+  };
+  const url = new URL(`https://api.utdnebula.com/section/${sectionID}`); // Call the SectionById function
+  return new Promise<void>((resolve) => {
+    fetch(url.href, {
+      method: 'GET',
+      headers: headers,
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        //console.log('data', data, data.message);
+        if (data.message !== 'success') {
+          throw new Error(data.message);
+        }
+        res.status(200).json({
+          message: 'success',
+          data: data.data,
+        });
+        resolve();
+      })
+      .catch((error) => {
+        res.status(400).json({ message: error.message });
+        resolve();
+      });
+  });
+}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -17,7 +17,7 @@ import Carousel from '@/components/navigation/Carousel/carousel';
 import TopMenu from '@/components/navigation/topMenu/topMenu';
 import CourseOverview from '@/components/overview/CourseOverview/courseOverview';
 import ProfessorOverview from '@/components/overview/ProfessorOverview/professorOverview';
-import Filters from '@/components/search/Filters/filters';
+import Filters, { compareSemesters } from '@/components/search/Filters/filters';
 import SearchResultsTable from '@/components/search/SearchResultsTable/searchResultsTable';
 import { compareColors } from '@/modules/colors/colors';
 import fetchWithCache, {
@@ -164,6 +164,7 @@ function calculateGrades(grades: GradesData, academicSessions?: string[]) {
     gpa: gpa,
     total: total,
     grade_distribution: grade_distribution,
+    most_recent_semester: grades.map((session) => session._id).sort((a, b) => compareSemesters(b, a))[0],
   };
 }
 export type GradesType = {
@@ -171,6 +172,7 @@ export type GradesType = {
   total: number;
   grade_distribution: number[];
   grades: GradesData;
+  most_recent_semester: string;
 };
 //Fetch grades by academic session from nebula api
 function fetchGradesData(

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -20,7 +20,6 @@ import ProfessorOverview, {
   type ProfessorInterface,
 } from '@/components/overview/ProfessorOverview/professorOverview';
 import Filters from '@/components/search/Filters/filters';
-import { compareSemesters } from '@/modules/semesters/semesters';
 import SearchResultsTable from '@/components/search/SearchResultsTable/searchResultsTable';
 import { compareColors } from '@/modules/colors/colors';
 import fetchWithCache, {
@@ -35,6 +34,7 @@ import {
   searchQueryEqual,
   searchQueryLabel,
 } from '@/modules/SearchQuery/SearchQuery';
+import { compareSemesters } from '@/modules/semesters/semesters';
 import type { CourseData } from '@/pages/api/course';
 import type { GradesData } from '@/pages/api/grades';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
@@ -220,9 +220,7 @@ function fetchGradesData(
 }
 
 //Fetch courses from nebula api
-function fetchCourseData(
-  course: SearchQuery,
-): Promise<CourseData[]> {
+function fetchCourseData(course: SearchQuery): Promise<CourseData[]> {
   return fetchWithCache(
     '/api/course?prefix=' +
       encodeURIComponent(String(course.prefix)) +
@@ -250,9 +248,7 @@ function fetchCourseData(
 }
 
 //Fetch a section from nebula api
-function fetchSectionData(
-  sectionID: string,
-): Promise<SectionData> {
+function fetchSectionData(sectionID: string): Promise<SectionData> {
   return fetchWithCache(
     '/api/section?sectionID=' + sectionID,
     cacheIndexNebula,
@@ -275,17 +271,13 @@ function fetchSectionData(
 function fetchSectionsDataForCourse(
   course: SearchQuery,
 ): Promise<SectionData[]> {
-  return fetchCourseData(course).then(
-    (courseDatas: CourseData[]) => {
-      return Promise.all(
-        courseDatas.flatMap((courseData) =>
-          courseData.sections.map((sectionID) =>
-            fetchSectionData(sectionID),
-          ),
-        ),
-      );
-    },
-  );
+  return fetchCourseData(course).then((courseDatas: CourseData[]) => {
+    return Promise.all(
+      courseDatas.flatMap((courseData) =>
+        courseData.sections.map((sectionID) => fetchSectionData(sectionID)),
+      ),
+    );
+  });
 }
 
 //Fetch RMP data from RMP

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -164,7 +164,9 @@ function calculateGrades(grades: GradesData, academicSessions?: string[]) {
     gpa: gpa,
     total: total,
     grade_distribution: grade_distribution,
-    most_recent_semester: grades.map((session) => session._id).sort((a, b) => compareSemesters(b, a))[0],
+    most_recent_semester: grades
+      .map((session) => session._id)
+      .sort((a, b) => compareSemesters(b, a))[0],
   };
 }
 export type GradesType = {


### PR DESCRIPTION
## Overview

When scanning search results, some professors may have not taught in a while (making them less viable options)

Implements #280 

## What Changed

Added a `most_recent_semester` prop to the `GradesType` type, which is filled in `calculateGrades` (_dashboard/index.tsx_)
Then, call that prop to fill the badge in _searchResultsTable.tsx_'s row

## Other Notes