### PR TITLE
Disable Prettier new line changes

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -5,4 +5,5 @@ module.exports = {
   tabWidth: 2,
   trailingComma: 'all',
   useTabs: false,
+  endOfLine: 'auto',
 };


### PR DESCRIPTION
Stops prettier from changing all line endings to `\n` which looks like a lot of changes, only for git to remove the changes when you do `git add .`