### PR TITLE
Prevent Users from opening course cards with empty search results

### DIFF
--- a/src/components/search/SearchResultsTable/searchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/searchResultsTable.tsx
@@ -83,13 +83,15 @@ function Row({
   color,
 }: RowProps) {
   const [open, setOpen] = useState(false);
-
+  const canOpen = 
+  !(typeof grades === 'undefined' || grades.state === 'error') ||
+  !(typeof rmp === 'undefined' || rmp.state === 'error');
   const rainbowColors = useRainbowColors();
 
   return (
     <>
       <TableRow
-        onClick={() => setOpen(!open)} // opens/closes the card by clicking anywhere on the row
+        onClick={() => {if(canOpen) setOpen(!open)}} // opens/closes the card by clicking anywhere on the row
         className="cursor-pointer"
       >
         <TableCell className="border-b-0">
@@ -101,9 +103,10 @@ function Row({
               <IconButton
                 aria-label="expand row"
                 size="medium"
+                disabled={!canOpen}
                 onClick={(e) => {
                   e.stopPropagation(); // prevents double opening/closing
-                  setOpen(!open);
+                  if(canOpen) setOpen(!open);
                 }}
                 className={'transition-transform' + (open ? ' rotate-90' : '')}
               >


### PR DESCRIPTION
Used skedge's code to implement canOpen checks if search results didnt exist, disabling the arrow icon if it isnt openable.