### PR TITLE
365 feature request pass section data for selected results into my planner

### DIFF
--- a/src/modules/SearchQuery/SearchQuery.tsx
+++ b/src/modules/SearchQuery/SearchQuery.tsx
@@ -11,6 +11,11 @@ export type Professor = {
   profLast: string;
 };
 
+export type Course = {
+  prefix: string;
+  number: string;
+};
+
 export function convertToProfOnly(
   searchQuery: SearchQuery,
 ): Professor | Record<string, never> {
@@ -20,6 +25,18 @@ export function convertToProfOnly(
   return {
     profFirst: searchQuery.profFirst as string,
     profLast: searchQuery.profLast as string,
+  };
+}
+
+export function convertToCourseOnly(
+  searchQuery: SearchQuery,
+): Course | Record<string, never> {
+  if (!('prefix' in searchQuery && 'number' in searchQuery)) {
+    return {};
+  }
+  return {
+    prefix: searchQuery.prefix as string,
+    number: searchQuery.number as string,
   };
 }
 

--- a/src/modules/SectionsType/SectionsType.ts
+++ b/src/modules/SectionsType/SectionsType.ts
@@ -1,0 +1,6 @@
+import type { SectionsData } from '@/pages/api/sections';
+
+export type SectionsType = {
+  all: SectionsData;
+  latest: SectionsData;
+};

--- a/src/modules/semesters/semesters.tsx
+++ b/src/modules/semesters/semesters.tsx
@@ -1,0 +1,14 @@
+/** A comparator function used when sorting semesters by name. Returns -1 if semester 'a' is more older than semester 'b'. */
+export function compareSemesters(a: string, b: string) {
+  const x = a.substring(0, 2).localeCompare(b.substring(0, 2));
+  if (x == 0) {
+    const a_char = a[2];
+    const b_char = b[2];
+    // a_char and b_char cannot both be the same semester because x == 0
+    if (a_char == 'S') return -1;
+    if (a_char == 'U' && b_char == 'S') return 1;
+    if (a_char == 'U' && b_char == 'F') return -1;
+    if (a_char == 'F') return 1;
+    return 0;
+  } else return x;
+}

--- a/src/modules/useSectionsStore/useSectionsStore.ts
+++ b/src/modules/useSectionsStore/useSectionsStore.ts
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+
+import fetchWithCache, {
+  cacheIndexNebula,
+  expireTime,
+} from '@/modules/fetchWithCache/fetchWithCache';
+import type { GenericFetchedData } from '@/modules/GenericFetchedData/GenericFetchedData';
+import {
+  convertToCourseOnly,
+  convertToProfOnly,
+  type SearchQuery,
+  searchQueryLabel,
+} from '@/modules/SearchQuery/SearchQuery';
+import type { SectionData } from '@/pages/api/sections';
+
+//Fetch section data from nebula api
+function fetchSectionsData(
+  query: SearchQuery,
+  controller: AbortController,
+): Promise<SectionData> {
+  return fetchWithCache(
+    '/api/sections?' +
+      Object.keys(query)
+        .map(
+          (key) =>
+            key +
+            '=' +
+            encodeURIComponent(String(query[key as keyof SearchQuery])),
+        )
+        .join('&'),
+    cacheIndexNebula,
+    expireTime,
+    {
+      signal: controller.signal,
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  ).then((response) => {
+    if (response.message !== 'success') {
+      throw new Error(response.message);
+    }
+    return response.data;
+  });
+}
+
+//Limit cached number of data entries
+const MAX_ENTRIES = 1000;
+
+interface Sections {
+  [key: string]: GenericFetchedData<SectionData>;
+}
+
+export default function useSectionsStore(): [
+  Sections,
+  (arg0: Sections | ((arg0: Sections) => Sections)) => void,
+  (combo: SearchQuery, controller: AbortController) => void,
+] {
+  const [sections, setSections] = useState<Sections>({});
+
+  function addToSections(key: string, value: GenericFetchedData<SectionData>) {
+    setSections((old) => {
+      const newVal = { ...old };
+      if (typeof newVal[key] !== 'undefined') {
+        newVal[key] = value;
+        return newVal;
+      }
+      if (Object.keys(newVal).length >= MAX_ENTRIES) {
+        // Remove the oldest entry
+        const oldestKey = Object.keys(newVal)[0];
+        delete newVal[oldestKey];
+      }
+      newVal[key] = value;
+      return newVal;
+    });
+  }
+
+  //Call fetchSectionsData and store response
+  function fetchAndStoreSectionsData(
+    combo: SearchQuery,
+    controller: AbortController,
+  ) {
+    addToSections(searchQueryLabel(combo), { state: 'loading' });
+    const seperatedCombo = [
+      convertToCourseOnly(combo),
+      convertToProfOnly(combo),
+    ]
+      //Remove empty objects (for non combos)
+      .filter((obj) => Object.keys(obj).length !== 0);
+    Promise.all(
+      seperatedCombo.map((query) => fetchSectionsData(query, controller)),
+    )
+      .then((res: SectionData[]) => {
+        //Find intersection of all course sections and all professor sections
+        let intersection: SectionData = [];
+        if (res.length === 1) {
+          intersection = res[0];
+        } else if (res.length === 2) {
+          intersection = res[0].filter(
+            (value) => res[1].findIndex((val) => val._id === value._id) !== -1,
+          );
+        }
+        //Add to storage
+        //Set loading status to done
+        addToSections(searchQueryLabel(combo), {
+          state: 'done',
+          data: intersection,
+        });
+      })
+      .catch(() => {
+        //Set loading status to error
+        addToSections(searchQueryLabel(combo), { state: 'error' });
+      });
+  }
+
+  return [sections, setSections, fetchAndStoreSectionsData];
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -21,6 +21,7 @@ import {
 import useGradeStore from '@/modules/useGradeStore/useGradeStore';
 import usePersistantState from '@/modules/usePersistantState/usePersistantState';
 import useRmpStore from '@/modules/useRmpStore/useRmpStore';
+import useSectionsStore from '@/modules/useSectionsStore/useSectionsStore';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -155,6 +156,9 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   }
 
+  //Store sections by course+prof combo
+  const [sections, , fetchAndStoreSectionsData] = useSectionsStore();
+
   return (
     <>
       <GoogleAnalytics gaId="G-CC86XR1562" />
@@ -201,6 +205,8 @@ function MyApp({ Component, pageProps }: AppProps) {
             recalcAllGrades={recalcAllGrades}
             rmp={rmp}
             fetchAndStoreRmpData={fetchAndStoreRmpData}
+            sections={sections}
+            fetchAndStoreSectionsData={fetchAndStoreSectionsData}
           />
           <FeedbackPopup />
           <GitHubButton />

--- a/src/pages/api/sections.ts
+++ b/src/pages/api/sections.ts
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-export type SectionData = {
+export type SectionsData = {
   _id: string;
   section_number: string;
   course_reference: string;
@@ -41,7 +41,7 @@ export type SectionData = {
 
 type Data = {
   message: string;
-  data?: SectionData;
+  data?: SectionsData;
 };
 
 export default function handler(
@@ -76,7 +76,7 @@ export default function handler(
     Accept: 'application/json',
   };
 
-  function recursiveFetch(url: URL, offset: number): Promise<SectionData> {
+  function recursiveFetch(url: URL, offset: number): Promise<SectionsData> {
     const offsetUrl = new URL(url);
     offsetUrl.searchParams.append('latter_offset', offset.toString());
 

--- a/src/pages/api/sections.ts
+++ b/src/pages/api/sections.ts
@@ -1,0 +1,100 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export type SectionData = {
+  _id: string;
+  section_number: string;
+  course_reference: string;
+  section_corequisites: null;
+  academic_session: {
+    name: string;
+    start_date: string;
+    end_date: string;
+  };
+  professors: string[];
+  teaching_assistants: {
+    first_name: string;
+    last_name: string;
+    role: string;
+    email: string;
+  };
+  internal_class_number: string;
+  instruction_mode: string;
+  meetings: {
+    start_date: string;
+    end_date: string;
+    meeting_days: string[];
+    start_time: string;
+    end_time: string;
+    modality: string;
+    location: {
+      building: string;
+      room: string;
+      map_uri: string;
+    };
+  }[];
+  core_flags: string[];
+  syllabus_uri: string;
+  grade_distribution: number[];
+  attributes: unknown;
+}[];
+
+type Data = {
+  message: string;
+  data?: SectionData;
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>,
+) {
+  const API_KEY = process.env.REACT_APP_NEBULA_API_KEY;
+  if (typeof API_KEY !== 'string') {
+    res.status(500).json({ message: 'API key is undefined' });
+    return;
+  }
+  let url;
+  const prefix = req.query.prefix;
+  const number = req.query.number;
+  const profFirst = req.query.profFirst;
+  const profLast = req.query.profLast;
+  if (typeof prefix === 'string' && typeof number === 'string') {
+    url = new URL('https://api.utdnebula.com/course/sections');
+    url.searchParams.append('subject_prefix', prefix);
+    url.searchParams.append('course_number', number);
+  } else if (typeof profFirst === 'string' && typeof profLast === 'string') {
+    url = new URL('https://api.utdnebula.com/professor/sections');
+    url.searchParams.append('first_name', profFirst);
+    url.searchParams.append('last_name', profLast);
+  }
+  if (typeof url === 'undefined') {
+    res.status(400).json({ message: 'Incorrect query present' });
+    return;
+  }
+  const headers = {
+    'x-api-key': API_KEY,
+    Accept: 'application/json',
+  };
+
+  return new Promise<void>((resolve) => {
+    fetch(url.href, {
+      method: 'GET',
+      headers: headers,
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.message !== 'success') {
+          throw new Error(data.message);
+        }
+        res.status(200).json({
+          message: 'success',
+          data: data.data,
+        });
+        resolve();
+      })
+      .catch((error) => {
+        res.status(400).json({ message: error.message });
+        resolve();
+      });
+  });
+}

--- a/src/pages/planner/index.tsx
+++ b/src/pages/planner/index.tsx
@@ -20,6 +20,7 @@ import {
   searchQueryLabel,
 } from '@/modules/SearchQuery/SearchQuery';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
+import type { SectionData } from '@/pages/api/sections';
 
 function removeDuplicates(array: SearchQuery[]) {
   return array.filter(
@@ -46,6 +47,13 @@ interface Props {
   };
   fetchAndStoreRmpData: (
     course: SearchQuery,
+    controller: AbortController,
+  ) => void;
+  sections: {
+    [key: string]: GenericFetchedData<SectionData>;
+  };
+  fetchAndStoreSectionsData: (
+    combo: SearchQuery,
     controller: AbortController,
   ) => void;
 }
@@ -86,12 +94,21 @@ export const MyPlanner: NextPage<Props> = (props: Props): React.ReactNode => {
         }
       }
 
+      //Section data
+      for (const result of planner) {
+        const entry = props.sections[searchQueryLabel(result)];
+        //Not already loading
+        if (typeof entry === 'undefined' || entry.state === 'error') {
+          props.fetchAndStoreSectionsData(result, controller);
+        }
+      }
+
       return () => {
         controller.abort();
       };
     }
   }, [planner]);
-  console.log(props.grades, props.rmp);
+  console.log(props.grades, props.rmp, props.sections);
 
   let results: GenericFetchedData<SearchQuery[]> = {
     state: 'loading',

--- a/src/pages/planner/index.tsx
+++ b/src/pages/planner/index.tsx
@@ -19,8 +19,8 @@ import {
   searchQueryEqual,
   searchQueryLabel,
 } from '@/modules/SearchQuery/SearchQuery';
+import type { SectionsType } from '@/modules/SectionsType/SectionsType';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
-import type { SectionData } from '@/pages/api/sections';
 
 function removeDuplicates(array: SearchQuery[]) {
   return array.filter(
@@ -50,7 +50,7 @@ interface Props {
     controller: AbortController,
   ) => void;
   sections: {
-    [key: string]: GenericFetchedData<SectionData>;
+    [key: string]: GenericFetchedData<SectionsType>;
   };
   fetchAndStoreSectionsData: (
     combo: SearchQuery,


### PR DESCRIPTION
## Overview

Resolves #365 

Adds fetching logic to get sections being taught for course professor combos

## What Changed

Adds `src/modules/useSectionsStore/useSectionsStore.ts` similar to the grades and rmp ones. Differences are this one fetches a common class on initialization (GOVT 2306) to find the newest semester in the database. And for a combo this must do 2 fetches (which is really even more due to pagination) and then take the intersection of them.

## Other Notes

Stole some code in `src/modules/SearchQuery/SearchQuery.tsx` and `src\modules\semesters\semesters.tsx` from #340 which could probably also use this code on the dashboard.

To test, go to the dashboard and add some combos to planner (maybe make sure that prof is actually teaching this semester). Then go to the planner page and look in the console where the fetched grade, rmp, and section data is.