### PR TITLE
Open card when clicking on text

### DIFF
--- a/src/components/search/SearchResultsTable/SearchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/SearchResultsTable.tsx
@@ -104,12 +104,7 @@ function Row({
       }
       placement="top"
     >
-      <Typography
-        onClick={
-          (e) => e.stopPropagation() // prevents opening/closing the card when clicking on the text
-        }
-        className="leading-tight text-lg text-gray-600 dark:text-gray-200 cursor-text w-fit"
-      >
+      <Typography className="leading-tight text-lg text-gray-600 dark:text-gray-200 cursor-text w-fit">
         {searchQueryLabel(course) +
           ((typeof course.profFirst === 'undefined' &&
             typeof course.profLast === 'undefined') ||

--- a/src/components/search/SearchResultsTable/SearchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/SearchResultsTable.tsx
@@ -104,7 +104,7 @@ function Row({
       }
       placement="top"
     >
-      <Typography className="leading-tight text-lg text-gray-600 dark:text-gray-200 cursor-text w-fit">
+      <Typography className="leading-tight text-lg text-gray-600 dark:text-gray-200 w-fit">
         {searchQueryLabel(course) +
           ((typeof course.profFirst === 'undefined' &&
             typeof course.profLast === 'undefined') ||
@@ -118,7 +118,10 @@ function Row({
 
   return (
     <>
-      <TableRow onClick={() => setOpen(!open)} className="table-row sm:hidden">
+      <TableRow
+        onClick={() => setOpen(!open)}
+        className="cursor-pointer table-row sm:hidden"
+      >
         <TableCell
           component="th"
           scope="row"


### PR DESCRIPTION
I had disabled opening the card when clicking on the text in case you wanted to copy something but this causes too much confusion as the text is the main space to click on the card.

This PR makes clicking on the text open the card.