### PR TITLE
Update planner choices across tabs

### DIFF
--- a/src/modules/usePersistantState/usePersistantState.tsx
+++ b/src/modules/usePersistantState/usePersistantState.tsx
@@ -7,11 +7,28 @@ export default function usePersistantState<T>(
   const [state, setInternalState] = useState<T>(initialValue);
 
   useEffect(() => {
-    const value = localStorage.getItem(key);
+    function setFromStorage() {
+      const value = localStorage.getItem(key);
+      if (!value) return;
+      let parsed;
+      try {
+        parsed = JSON.parse(value);
+      } catch (e) {
+        setInternalState(initialValue);
+        return;
+      }
+      setInternalState(parsed);
+    }
+    setFromStorage();
 
-    if (!value) return;
-
-    setInternalState(JSON.parse(value));
+    // Update when another tab changes localStorage
+    function handleChange(event) {
+      if (event.key === key) {
+        setFromStorage();
+      }
+    }
+    window.addEventListener('storage', handleChange);
+    return () => window.removeEventListener('storage', handleChange);
   }, [key]);
 
   const setState = (value: T) => {

--- a/src/modules/usePersistantState/usePersistantState.tsx
+++ b/src/modules/usePersistantState/usePersistantState.tsx
@@ -13,7 +13,7 @@ export default function usePersistantState<T>(
       let parsed;
       try {
         parsed = JSON.parse(value);
-      } catch (e) {
+      } catch {
         setInternalState(initialValue);
         return;
       }

--- a/src/modules/usePersistantState/usePersistantState.tsx
+++ b/src/modules/usePersistantState/usePersistantState.tsx
@@ -22,7 +22,7 @@ export default function usePersistantState<T>(
     setFromStorage();
 
     // Update when another tab changes localStorage
-    function handleChange(event) {
+    function handleChange(event: StorageEvent) {
       if (event.key === key) {
         setFromStorage();
       }


### PR DESCRIPTION
If you have dashboard open in one tab and planner open in another this will keep them in sync by listening for changes