### PR TITLE
Rule 1 fix for lab+test sections

### DIFF
--- a/src/components/planner/PlannerCoursesTable/PlannerCard/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard/PlannerCard.tsx
@@ -32,6 +32,7 @@ import {
   searchQueryLabel,
   type SearchQueryMultiSection,
 } from '@/modules/SearchQuery/SearchQuery';
+import sectionCanOverlap from '@/modules/sections/sections';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
 import { type SectionsData } from '@/pages/api/sections';
 
@@ -126,12 +127,21 @@ function SectionTableRow(props: SectionTableRowProps) {
   return (
     <TableRow>
       <TableCell className={props.lastRow ? 'border-b-0' : ''}>
-        <Radio
-          checked={isSelected}
-          onClick={() => {
-            props.setPlannerSection(props.course, props.data.section_number);
-          }}
-        />
+        {sectionCanOverlap(props.data.section_number) ? (
+          <Checkbox
+            checked={isSelected}
+            onClick={() => {
+              props.setPlannerSection(props.course, props.data.section_number);
+            }}
+          />
+        ) : (
+          <Radio
+            checked={isSelected}
+            onClick={() => {
+              props.setPlannerSection(props.course, props.data.section_number);
+            }}
+          />
+        )}
       </TableCell>
       <TableCell className={props.lastRow ? 'border-b-0' : ''}>
         <Typography>{props.data.section_number}</Typography>

--- a/src/components/planner/PlannerCoursesTable/PlannerCard/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard/PlannerCard.tsx
@@ -30,6 +30,7 @@ import {
   removeSection,
   type SearchQuery,
   searchQueryLabel,
+  type SearchQueryMultiSection,
 } from '@/modules/SearchQuery/SearchQuery';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
 import { type SectionsData } from '@/pages/api/sections';
@@ -114,27 +115,21 @@ function parseMeeting(meeting: SectionsData[number]['meetings'][number]) {
 
 type SectionTableRowProps = {
   data: SectionsData[number];
-  course: SearchQuery;
+  course: SearchQueryMultiSection;
   lastRow: boolean;
-  setPlannerSection: (
-    searchQuery: SearchQuery,
-    section: string | undefined,
-  ) => boolean;
+  setPlannerSection: (searchQuery: SearchQuery, section: string) => boolean;
 };
 
 function SectionTableRow(props: SectionTableRowProps) {
-  const isSelected = props.course.sectionNumber === props.data.section_number;
+  const isSelected =
+    props.course.sectionNumbers?.includes(props.data.section_number) ?? false;
   return (
     <TableRow>
       <TableCell className={props.lastRow ? 'border-b-0' : ''}>
         <Radio
           checked={isSelected}
           onClick={() => {
-            if (!isSelected) {
-              props.setPlannerSection(props.course, props.data.section_number);
-            } else {
-              props.setPlannerSection(props.course, undefined);
-            }
+            props.setPlannerSection(props.course, props.data.section_number);
           }}
         />
       </TableCell>
@@ -175,12 +170,9 @@ function SectionTableRow(props: SectionTableRowProps) {
 }
 
 type PlannerCardProps = {
-  query: SearchQuery;
+  query: SearchQueryMultiSection;
   sections?: SectionsData;
-  setPlannerSection: (
-    searchQuery: SearchQuery,
-    section: string | undefined,
-  ) => boolean;
+  setPlannerSection: (searchQuery: SearchQuery, section: string) => boolean;
   grades: GenericFetchedData<GradesType>;
   rmp: GenericFetchedData<RMPInterface>;
   removeFromPlanner: () => void;

--- a/src/components/planner/PlannerCoursesTable/PlannerCoursesTable.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCoursesTable.tsx
@@ -13,6 +13,7 @@ import {
   searchQueryLabel,
   type SearchQueryMultiSection,
 } from '@/modules/SearchQuery/SearchQuery';
+import sectionCanOverlap from '@/modules/sections/sections';
 import { type SectionsType } from '@/modules/SectionsType/SectionsType';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
 
@@ -53,7 +54,12 @@ const PlannerCoursesTable = (props: PlannerCoursesTableProps) => {
                     typeof sectionData === 'undefined' ||
                     sectionData.state === 'error'
                       ? undefined
-                      : sectionData.data.latest
+                      : sectionData.data.latest.filter(
+                          (section) =>
+                            typeof course.profFirst === 'undefined' &&
+                            typeof course.profLast === 'undefined' &&
+                            sectionCanOverlap(section.section_number),
+                        )
                   }
                   setPlannerSection={props.setPlannerSection}
                   grades={props.grades[searchQueryLabel(removeSection(course))]}

--- a/src/components/planner/PlannerCoursesTable/PlannerCoursesTable.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCoursesTable.tsx
@@ -11,18 +11,16 @@ import {
   removeSection,
   type SearchQuery,
   searchQueryLabel,
+  type SearchQueryMultiSection,
 } from '@/modules/SearchQuery/SearchQuery';
 import { type SectionsType } from '@/modules/SectionsType/SectionsType';
 import type { RMPInterface } from '@/pages/api/ratemyprofessorScraper';
 
 type PlannerCoursesTableProps = {
-  courses?: SearchQuery[];
+  courses?: SearchQueryMultiSection[];
   addToPlanner: (value: SearchQuery) => void;
   removeFromPlanner: (value: SearchQuery) => void;
-  setPlannerSection: (
-    searchQuery: SearchQuery,
-    section: string | undefined,
-  ) => boolean;
+  setPlannerSection: (searchQuery: SearchQuery, section: string) => boolean;
   sections: {
     [key: string]: GenericFetchedData<SectionsType>;
   };

--- a/src/modules/SearchQuery/SearchQuery.tsx
+++ b/src/modules/SearchQuery/SearchQuery.tsx
@@ -16,6 +16,14 @@ export type Course = {
   number: string;
 };
 
+export type SearchQueryMultiSection = {
+  prefix?: string;
+  number?: string;
+  profFirst?: string;
+  profLast?: string;
+  sectionNumbers?: string[];
+};
+
 export function convertToProfOnly(
   searchQuery: SearchQuery,
 ): Professor | Record<string, never> {
@@ -40,10 +48,30 @@ export function convertToCourseOnly(
   };
 }
 
-export function removeSection(searchQuery: SearchQuery): SearchQuery {
+export function removeSection(
+  searchQuery: SearchQuery | SearchQueryMultiSection,
+): SearchQuery {
   const result = { ...searchQuery };
-  delete result.sectionNumber;
+  if ('sectionNumber' in result) {
+    delete result.sectionNumber;
+  }
+  if ('sectionNumbers' in result) {
+    delete result.sectionNumbers;
+  }
   return result;
+}
+
+export function searchQueryMultiSectionSplit(
+  searchQuery: SearchQueryMultiSection,
+): SearchQuery[] {
+  if (typeof searchQuery.sectionNumbers === 'undefined') {
+    return [];
+  }
+  return searchQuery.sectionNumbers.map((section) => {
+    const result = { ...searchQuery, sectionNumber: section };
+    delete result.sectionNumbers;
+    return result;
+  });
 }
 
 export function searchQueryLabel(query: SearchQuery): string {

--- a/src/modules/sections/sections.tsx
+++ b/src/modules/sections/sections.tsx
@@ -1,0 +1,3 @@
+export default function sectionCanOverlap(section: string): boolean {
+  return /^[12367]/.test(section);
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -18,6 +18,7 @@ import {
   removeSection,
   type SearchQuery,
   searchQueryEqual,
+  type SearchQueryMultiSection,
 } from '@/modules/SearchQuery/SearchQuery';
 import useGradeStore from '@/modules/useGradeStore/useGradeStore';
 import usePersistantState from '@/modules/usePersistantState/usePersistantState';
@@ -155,7 +156,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   const [rmp, , fetchAndStoreRmpData] = useRmpStore();
 
   //Store course+prof combos in planner
-  const [planner, setPlanner] = usePersistantState<SearchQuery[]>(
+  const [planner, setPlanner] = usePersistantState<SearchQueryMultiSection[]>(
     'planner',
     [],
   );
@@ -178,18 +179,30 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   }
 
-  function setPlannerSection(
-    searchQuery: SearchQuery,
-    section: string | undefined,
-  ) {
+  function setPlannerSection(searchQuery: SearchQuery, section: string) {
     setPlanner(
       planner.map((course) => {
-        return searchQueryEqual(
-          removeSection(course),
-          removeSection(searchQuery),
-        )
-          ? { ...course, sectionNumber: section }
-          : course;
+        if (
+          searchQueryEqual(removeSection(course), removeSection(searchQuery))
+        ) {
+          if (typeof course.sectionNumbers === 'undefined') {
+            return { ...course, sectionNumbers: [section] };
+          }
+          if (course.sectionNumbers.includes(section)) {
+            return {
+              ...course,
+              sectionNumbers: course.sectionNumbers.filter(
+                (s) => s !== section,
+              ),
+            };
+          } else {
+            return {
+              ...course,
+              sectionNumbers: course.sectionNumbers.concat([section]),
+            };
+          }
+        }
+        return course;
       }),
     );
   }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,7 @@ import {
   searchQueryEqual,
   type SearchQueryMultiSection,
 } from '@/modules/SearchQuery/SearchQuery';
+import sectionCanOverlap from '@/modules/sections/sections';
 import useGradeStore from '@/modules/useGradeStore/useGradeStore';
 import usePersistantState from '@/modules/usePersistantState/usePersistantState';
 import useRmpStore from '@/modules/useRmpStore/useRmpStore';
@@ -196,9 +197,13 @@ function MyApp({ Component, pageProps }: AppProps) {
               ),
             };
           } else {
+            let newSections = course.sectionNumbers;
+            if (!sectionCanOverlap(section)) {
+              newSections = newSections.filter((s) => sectionCanOverlap(s));
+            }
             return {
               ...course,
-              sectionNumbers: course.sectionNumbers.concat([section]),
+              sectionNumbers: newSections.concat([section]),
             };
           }
         }

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -29,9 +29,11 @@ import type { GradesType } from '@/modules/GradesType/GradesType';
 import {
   convertToProfOnly,
   decodeSearchQueryLabel,
+  removeSection,
   type SearchQuery,
   searchQueryEqual,
   searchQueryLabel,
+  type SearchQueryMultiSection,
 } from '@/modules/SearchQuery/SearchQuery';
 import useGradeStore from '@/modules/useGradeStore/useGradeStore';
 import useRmpStore from '@/modules/useRmpStore/useRmpStore';
@@ -188,7 +190,7 @@ export async function getServerSideProps(
 
 interface Props {
   pageTitle: string;
-  planner: SearchQuery[];
+  planner: SearchQueryMultiSection[];
   addToPlanner: (value: SearchQuery) => void;
   removeFromPlanner: (value: SearchQuery) => void;
   grades: {
@@ -595,7 +597,7 @@ export const Dashboard: NextPage<Props> = (props: Props): React.ReactNode => {
         addToCompare={addToCompare}
         removeFromCompare={removeFromCompare}
         colorMap={colorMap}
-        planner={props.planner}
+        planner={props.planner.map((x) => removeSection(x))}
         addToPlanner={props.addToPlanner}
         removeFromPlanner={props.removeFromPlanner}
       />


### PR DESCRIPTION
Fix to allow selection multiple sections but only when they are:
- 1xx: Lab section (sciences)
- 2xx: Discussion section (humanities)
- 3xx: Problem section (maths)
- 5xx: Night lecture (past 5 PM)
- 6xx: Lab night section (past 7 PM)
- 7xx: Exam section

Does this by adding a new SearchQuery type that stores sectionNumbers (an array of strings) instead of sectionNumber (a string)