### PR TITLE
Warning fixes

### DIFF
--- a/src/components/common/WhatsNew/WhatsNew.tsx
+++ b/src/components/common/WhatsNew/WhatsNew.tsx
@@ -22,92 +22,64 @@ interface Feature {
   releaseId: string;
 }
 
-/**
- * WhatsNewButton component that shows the latest feature from GitHub releases
- */
-export function WhatsNewButton() {
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const [readFeatures, setReadFeatures] = usePersistantState<string[]>(
-    'readFeatures',
-    [],
-  );
-  const [latestFeatures, setLatestFeatures] = useState<Feature[]>([]);
-  const [state, setState] = useState('done');
+// Extract features from GitHub release content
+const extractFeaturesFromRelease = (releaseBody: string): string[] => {
+  const lines = releaseBody.split('\n');
+  const features: string[] = [];
 
-  // Check if the latest feature is unread
-  const unread = Boolean(
-    latestFeatures.find((feature) => !readFeatures.includes(feature.id)),
-  );
-  const open = Boolean(anchorEl);
+  let inOverviewSection = true;
 
-  // Fetch releases
-  useEffect(() => {
-    fetchReleases();
-  }, []);
+  for (const line of lines) {
+    const trimmedLine = line.trim();
 
-  // Extract features from GitHub release content
-  const extractFeaturesFromRelease = (releaseBody: string): string[] => {
-    const lines = releaseBody.split('\n');
-    const features: string[] = [];
+    if (trimmedLine.startsWith('## ')) {
+      inOverviewSection = false;
+      continue;
+    }
 
-    let inOverviewSection = true;
+    if (
+      inOverviewSection &&
+      (trimmedLine.startsWith('- ') || trimmedLine.startsWith('* '))
+    ) {
+      const featureContent = trimmedLine.replace(/^[-*]\s+/, '').trim();
+      if (featureContent) {
+        features.push(featureContent);
+      }
+    }
+  }
 
+  if (features.length === 0) {
     for (const line of lines) {
-      const trimmedLine = line.trim();
-
-      if (trimmedLine.startsWith('## ')) {
-        inOverviewSection = false;
-        continue;
-      }
-
-      if (
-        inOverviewSection &&
-        (trimmedLine.startsWith('- ') || trimmedLine.startsWith('* '))
-      ) {
-        const featureContent = trimmedLine.replace(/^[-*]\s+/, '').trim();
-        if (featureContent) {
-          features.push(featureContent);
-        }
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        features.push(trimmed);
+        break;
       }
     }
+  }
 
-    if (features.length === 0) {
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (trimmed && !trimmed.startsWith('#')) {
-          features.push(trimmed);
-          break;
-        }
-      }
-    }
+  return features;
+};
 
-    return features;
-  };
-
-  // Function to fetch only the 2 most recent releases
-  const fetchReleases = async () => {
-    if (state === 'loading') return;
-
-    setState('loading');
-
-    try {
-      const response = await fetch(
-        'https://api.github.com/repos/UTDNebula/utd-trends/releases?per_page=2',
-      );
-
+// Function to fetch only the 2 most recent releases
+const fetchReleases = async () => {
+  return fetch(
+    'https://api.github.com/repos/UTDNebula/utd-trends/releases?per_page=2',
+  )
+    .then((response) => {
       if (!response.ok) {
         throw new Error(`GitHub API responded with status: ${response.status}`);
       }
-
-      const releases = (await response.json()) as ReleaseData[];
-
-      if (!Array.isArray(releases) || releases.length === 0) {
-        return;
+      return response.json();
+    })
+    .then((response) => {
+      if (!Array.isArray(response) || response.length === 0) {
+        throw new Error('GitHub API responded with not known format');
       }
 
       const allFeatures: Feature[] = [];
 
-      releases.forEach((release: ReleaseData) => {
+      response.forEach((release: ReleaseData) => {
         if (release && release.body) {
           const extractedFeatures = extractFeaturesFromRelease(release.body);
           const featureVersion = release.name;
@@ -137,15 +109,38 @@ export function WhatsNewButton() {
         }
       });
 
-      if (allFeatures.length > 0) {
-        setLatestFeatures(allFeatures);
-      }
-    } catch {
-      setState('error');
-    } finally {
-      setState('done');
-    }
-  };
+      return allFeatures;
+    });
+};
+
+/**
+ * WhatsNewButton component that shows the latest feature from GitHub releases
+ */
+export function WhatsNewButton() {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const [readFeatures, setReadFeatures] = usePersistantState<string[]>(
+    'readFeatures',
+    [],
+  );
+  const [latestFeatures, setLatestFeatures] = useState<Feature[]>([]);
+  const [state, setState] = useState('done');
+
+  // Check if the latest feature is unread
+  const unread = Boolean(
+    latestFeatures.find((feature) => !readFeatures.includes(feature.id)),
+  );
+  const open = Boolean(anchorEl);
+
+  // Fetch releases
+  useEffect(() => {
+    setState('loading');
+    fetchReleases()
+      .then((response) => {
+        setLatestFeatures(response);
+        setState('done');
+      })
+      .catch(() => setState('error'));
+  }, []);
 
   // Handle opening the popover
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/navigation/Carousel/Carousel.tsx
+++ b/src/components/navigation/Carousel/Carousel.tsx
@@ -76,16 +76,18 @@ const Carousel = ({ names, children, compareLength }: CarouselProps) => {
   const [open, setOpen] = useState(false);
   useEffect(() => setOpen(!isSmallScreen), [isSmallScreen]);
   useEffect(() => {
-    if (lastCompareLength.current <= compareLength) {
-      setDirection(1);
-      setCurrentCard(Array.isArray(children) ? children.length - 1 : 0);
+    if (compareLength !== lastCompareLength.current) {
+      if (lastCompareLength.current <= compareLength) {
+        setDirection(1);
+        setCurrentCard(Array.isArray(children) ? children.length - 1 : 0);
+      }
+      if (lastCompareLength.current == 1 && compareLength == 0) {
+        setDirection(-1);
+        setCurrentCard(0);
+      }
+      lastCompareLength.current = compareLength;
     }
-    if (lastCompareLength.current == 1 && compareLength == 0) {
-      setDirection(-1);
-      setCurrentCard(0);
-    }
-    lastCompareLength.current = compareLength;
-  }, [compareLength]);
+  }, [compareLength, children]);
 
   return (
     <>

--- a/src/components/overview/ProfessorOverview/ProfessorOverview.tsx
+++ b/src/components/overview/ProfessorOverview/ProfessorOverview.tsx
@@ -89,8 +89,8 @@ const ProfessorOverview = ({
           height={280}
           width={280}
           className="w-32 h-32 rounded-full self-center"
-          onLoadingComplete={(result) => {
-            if (result.naturalWidth === 0) {
+          onLoad={(result) => {
+            if (result.currentTarget.naturalWidth === 0) {
               // Broken image
               setSrc(fallbackSrc);
             }

--- a/src/components/planner/PlannerCoursesTable/PlannerCard/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard/PlannerCard.tsx
@@ -363,13 +363,12 @@ const PlannerCard = (props: PlannerCardProps) => {
     canOpenSections ? 'sections' : canOpenGrades ? 'grades' : null,
   );
   useEffect(() => {
-    if (whichOpen === null) {
-      if (canOpenSections) {
-        setWhichOpen('sections');
-      } else if (canOpenGrades) {
-        setWhichOpen('grades');
+    setWhichOpen((prev) => {
+      if (prev === null) {
+        return canOpenSections ? 'sections' : canOpenGrades ? 'grades' : null;
       }
-    }
+      return prev;
+    });
   }, [canOpenSections, canOpenGrades]);
   function handleOpen() {
     if (

--- a/src/components/search/Filters/Filters.tsx
+++ b/src/components/search/Filters/Filters.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import Rating from '@/components/common/Rating/Rating';
 import gpaToLetterGrade from '@/modules/gpaToLetterGrade';
@@ -21,7 +21,6 @@ const minGPAs = ['3.67', '3.33', '3', '2.67', '2.33', '2'];
 const minRatings = ['4.5', '4', '3.5', '3', '2.5', '2', '1.5', '1', '0.5'];
 
 interface FiltersProps {
-  manageQuery?: boolean;
   academicSessions: string[];
   chosenSessions: string[];
   addChosenSessions: (arg0: (arg0: string[]) => string[]) => void;
@@ -31,35 +30,24 @@ interface FiltersProps {
  * This component returns a set of filters with which to sort results.
  */
 const Filters = ({
-  manageQuery,
   academicSessions,
   chosenSessions,
   addChosenSessions,
 }: FiltersProps) => {
-  const [minGPA, setMinGPA] = useState('');
-  const [minRating, setMinRating] = useState('');
-  const [filterNextSem, setFilterNextSem] = useState('false');
   const MAX_NUM_RECENT_SEMESTERS = 4; // recentSemesters will have up to the last 4 long-semesters
   const recentSemesters = getRecentSemesters(); // recentSemesters contains semesters offered in the last 2 years; recentSemesters.length = [0, 4] range
   academicSessions.sort((a, b) => compareSemesters(b, a)); // display the semesters in order of recency (most recent first)
 
-  //set value from query
   const router = useRouter();
-  useEffect(() => {
-    if (manageQuery) {
-      if (router.isReady && typeof router.query.searchTerms !== 'undefined') {
-        if (typeof router.query.minGPA === 'string') {
-          setMinGPA(router.query.minGPA);
-        }
-        if (typeof router.query.minRating === 'string') {
-          setMinRating(router.query.minRating);
-        }
-        if (typeof router.query.availability === 'string') {
-          setFilterNextSem(router.query.availability);
-        }
-      }
-    }
-  }, [router.isReady, router.query.minGPA, router.query.minRating]);
+  let minGPA = router.query.minGPA ?? '';
+  if (Array.isArray(minGPA)) {
+    minGPA = minGPA[0]; // if minGPA is an array, make it a string
+  }
+  let minRating = router.query.minRating ?? '';
+  if (Array.isArray(minRating)) {
+    minRating = minRating[0]; // if minRating is an array, make it a string
+  }
+  const filterNextSem = router.query.availability === 'true';
 
   function getRecentSemesters() {
     // get current month and year
@@ -89,30 +77,6 @@ const Filters = ({
     }
 
     return recentSemesters.filter((value) => academicSessions.includes(value));
-  }
-
-  //Update URL, state, and parent
-  async function onChange(
-    newValue: string,
-    toSet: 'minGPA' | 'minRating' | 'availability',
-    setter: (value: string) => void,
-  ) {
-    setter(newValue);
-    if (manageQuery && router.isReady) {
-      const newQuery = { ...router.query };
-      if (newValue !== '') {
-        newQuery[toSet] = newValue;
-      } else {
-        delete newQuery[toSet];
-      }
-      await router.replace(
-        {
-          query: newQuery,
-        },
-        undefined,
-        { shallow: true },
-      );
-    }
   }
 
   function displayAcademicSessionName(id: string) {
@@ -161,8 +125,23 @@ const Filters = ({
               label="Min Letter Grade"
               labelId="minGPA"
               value={minGPA}
-              onChange={async (event: SelectChangeEvent) => {
-                await onChange(event.target.value, 'minGPA', setMinGPA);
+              onChange={(event: SelectChangeEvent) => {
+                if (router.isReady) {
+                  const newQuery = { ...router.query };
+                  const newValue = event.target.value;
+                  if (newValue !== '') {
+                    newQuery.minGPA = newValue;
+                  } else {
+                    delete newQuery.minGPA;
+                  }
+                  router.replace(
+                    {
+                      query: newQuery,
+                    },
+                    undefined,
+                    { shallow: true },
+                  );
+                }
               }}
             >
               <MenuItem className="h-10" value="">
@@ -195,8 +174,23 @@ const Filters = ({
               label="Min Rating"
               labelId="minRating"
               value={minRating}
-              onChange={async (event: SelectChangeEvent) => {
-                await onChange(event.target.value, 'minRating', setMinRating);
+              onChange={(event: SelectChangeEvent) => {
+                if (router.isReady) {
+                  const newQuery = { ...router.query };
+                  const newValue = event.target.value;
+                  if (newValue !== '') {
+                    newQuery.minRating = newValue;
+                  } else {
+                    delete newQuery.minRating;
+                  }
+                  router.replace(
+                    {
+                      query: newQuery,
+                    },
+                    undefined,
+                    { shallow: true },
+                  );
+                }
               }}
               renderValue={(value) => (
                 <Rating
@@ -341,7 +335,7 @@ const Filters = ({
           <FormControl
             size="small"
             className={`${
-              filterNextSem === 'true'
+              filterNextSem
                 ? '[&>.MuiInputBase-root]:bg-cornflower-50 [&>.MuiInputBase-root]:dark:bg-cornflower-900'
                 : '[&>.MuiInputBase-root]:bg-white [&>.MuiInputBase-root]:dark:bg-black'
             }`}
@@ -349,13 +343,23 @@ const Filters = ({
             <FormControlLabel
               control={
                 <Switch
-                  checked={filterNextSem === 'true'}
+                  checked={filterNextSem}
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    onChange(
-                      event.target.checked ? 'true' : 'false',
-                      'availability',
-                      setFilterNextSem,
-                    );
+                    if (router.isReady) {
+                      const newQuery = { ...router.query };
+                      if (event.target.checked) {
+                        newQuery.availability = 'true';
+                      } else {
+                        delete newQuery.availability;
+                      }
+                      router.replace(
+                        {
+                          query: newQuery,
+                        },
+                        undefined,
+                        { shallow: true },
+                      );
+                    }
                   }}
                 />
               }

--- a/src/modules/usePersistantState.tsx
+++ b/src/modules/usePersistantState.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function usePersistantState<T>(
   key: string,
@@ -6,6 +6,7 @@ export default function usePersistantState<T>(
 ): [T, (value: T | ((old: T) => T)) => void] {
   const [state, setInternalState] = useState<T>(initialValue);
 
+  const initialValueRef = useRef(initialValue);
   useEffect(() => {
     function setFromStorage() {
       const value = localStorage.getItem(key);
@@ -14,7 +15,7 @@ export default function usePersistantState<T>(
       try {
         parsed = JSON.parse(value);
       } catch {
-        setInternalState(initialValue);
+        setInternalState(initialValueRef.current);
         return;
       }
       setInternalState(parsed);

--- a/src/modules/useRmpStore.ts
+++ b/src/modules/useRmpStore.ts
@@ -67,6 +67,10 @@ export default function useRmpStore(): [
     professor: SearchQuery,
     controller: AbortController,
   ) {
+    const entry = rmp[searchQueryLabel(professor)];
+    if (typeof entry !== 'undefined' && entry.state !== 'error') {
+      return;
+    }
     addToRmp(searchQueryLabel(professor), { state: 'loading' });
     fetchRmpData(professor, controller)
       .then((res: RMPInterface) => {

--- a/src/modules/useSectionsStore.ts
+++ b/src/modules/useSectionsStore.ts
@@ -102,6 +102,10 @@ export default function useSectionsStore(): [
     combo: SearchQuery,
     controller: AbortController,
   ) {
+    const entry = sections[searchQueryLabel(combo)];
+    if (typeof entry !== 'undefined' && entry.state !== 'error') {
+      return;
+    }
     addToSections(searchQueryLabel(combo), { state: 'loading' });
     //Wait for latestSemester to be found
     if (latestSemester.current === '') {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -151,8 +151,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
   //Store grades by course+prof combo
-  const [grades, , fetchAndStoreGradesData, recalcGrades, recalcAllGrades] =
-    useGradeStore();
+  const [grades, , fetchAndStoreGradesData, recalcAllGrades] = useGradeStore();
 
   //Store rmp scores by profs
   const [rmp, , fetchAndStoreRmpData] = useRmpStore();
@@ -279,7 +278,6 @@ function MyApp({ Component, pageProps }: AppProps) {
             setPlannerSection={setPlannerSection}
             grades={grades}
             fetchAndStoreGradesData={fetchAndStoreGradesData}
-            recalcGrades={recalcGrades}
             recalcAllGrades={recalcAllGrades}
             rmp={rmp}
             fetchAndStoreRmpData={fetchAndStoreRmpData}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -692,7 +692,6 @@ export const Dashboard: NextPage<Props> = (props: Props): React.ReactNode => {
     contentComponent = (
       <>
         <Filters
-          manageQuery
           academicSessions={academicSessions}
           chosenSessions={chosenSessions}
           addChosenSessions={addChosenSessions}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -200,7 +200,6 @@ interface Props {
     combo: SearchQuery,
     controller: AbortController,
   ) => void;
-  recalcGrades: (course: SearchQuery) => void;
   recalcAllGrades: (results: SearchQuery[], academicSessions: string[]) => void;
   rmp: {
     [key: string]: GenericFetchedData<RMPInterface>;
@@ -358,30 +357,17 @@ export const Dashboard: NextPage<Props> = (props: Props): React.ReactNode => {
     //Grade data
     //Fetch each result
     for (const result of results) {
-      // combo section data?
-      const sectEntry = props.sections[searchQueryLabel(result)];
-      //Not already loading
-      if (typeof sectEntry === 'undefined' || sectEntry.state === 'error') {
-        props.fetchAndStoreSectionsData(result, controller);
-      }
+      // combo section data
+      props.fetchAndStoreSectionsData(result, controller);
 
-      const entry = props.grades[searchQueryLabel(result)];
-      //Not already loading
-      if (typeof entry === 'undefined' || entry.state === 'error') {
-        props
-          .fetchAndStoreGradesData(result, controller)
-          .then((res: GradesType | null | undefined) => {
-            //Add any more academic sessions to list
-            if (res) {
-              addAcademicSessions(res.grades.map((session) => session._id));
-            }
-          });
-      } else if (entry.state === 'done') {
-        //Recalc gpa and such from past stored data for new page
-        props.recalcGrades(result);
-        //Readd academic sessions
-        addAcademicSessions(entry.data.grades.map((session) => session._id));
-      }
+      props
+        .fetchAndStoreGradesData(result, controller)
+        .then((res: GradesType | null | undefined) => {
+          //Add any more academic sessions to list
+          if (res) {
+            addAcademicSessions(res.grades.map((session) => session._id));
+          }
+        });
     }
 
     //RMP data
@@ -403,11 +389,7 @@ export const Dashboard: NextPage<Props> = (props: Props): React.ReactNode => {
       professorsInResults.push(professors[0]);
     }
     for (const professor of professorsInResults) {
-      const entry = props.rmp[searchQueryLabel(professor)];
-      //Not already loading
-      if (typeof entry === 'undefined' || entry.state === 'error') {
-        props.fetchAndStoreRmpData(professor, controller);
-      }
+      props.fetchAndStoreRmpData(professor, controller);
     }
   }
 
@@ -547,7 +529,7 @@ export const Dashboard: NextPage<Props> = (props: Props): React.ReactNode => {
   //List of course+prof combos saved for comparison
   const [compare, setCompare] = useState<SearchQuery[]>([]);
   //Their saved grade data
-  const [compareGrades, setCompareGrades, , , recalcAllCompareGrades] =
+  const [compareGrades, setCompareGrades, , recalcAllCompareGrades] =
     useGradeStore();
   //Saved data for their professors
   const [compareRmp, setCompareRmp] = useRmpStore();

--- a/src/pages/planner/index.tsx
+++ b/src/pages/planner/index.tsx
@@ -93,7 +93,7 @@ export const MyPlanner: NextPage<Props> = (props: Props): React.ReactNode => {
     fetchAndStoreSectionsData.current = props.fetchAndStoreSectionsData;
   }, [props.fetchAndStoreSectionsData]);
   useEffect(() => {
-    console.log('hi');
+    // console.log('hi');
     if (planner.length) {
       //To cancel on rerender
       const controller = new AbortController();


### PR DESCRIPTION
Fixed most of the ESLint warnings. Still not the ones on `dashboard/index.tsx`.

- `WhatsNew`: moved the fetch logic outside the components so it doesn't need to be in the useEffect dependency array.
- `Carousel`: add children to dependency array and an if statement to only really run when compare length changes.
- `PlannerCard`: use the prev value from setWhichOpen instead of whichOpen.
- `Filters`: use query as source of truth, not states.
- `usePersistantState`: initialValue shouldn't change so save it in a ref and don't update it.
- `planner/index`: useRef to not rerun when `fetchAndStoreGradesData` or the like changes.