### PR TITLE
Account for extra URL encoding

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
     searchTerms = searchTerms[0];
   }
   if (typeof searchTerms !== 'undefined') {
-    searchTerms = decodeURIComponent(searchTerms);
+    searchTerms = decodeURIComponent(searchTerms).replaceAll('+', ' ');
     const queries = searchTerms.split(',');
     const firstIsCourse =
       typeof decodeSearchQueryLabel(queries[0]).prefix !== 'undefined';
@@ -43,7 +43,7 @@ export async function generateMetadata({
           queries.slice(-1)) +
       " on Nebula Labs's data analytics platform to help you make informed decisions about your coursework with UT Dallas grade and Rate My Professors data.";
   }
-
+  console.log(title);
   return {
     title: 'Results' + title,
     description: description,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata({
           queries.slice(-1)) +
       " on Nebula Labs's data analytics platform to help you make informed decisions about your coursework with UT Dallas grade and Rate My Professors data.";
   }
-  console.log(title);
+
   return {
     title: 'Results' + title,
     description: description,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ export async function generateMetadata({
     searchTerms = searchTerms[0];
   }
   if (typeof searchTerms !== 'undefined') {
+    searchTerms = decodeURIComponent(searchTerms);
     const queries = searchTerms.split(',');
     const firstIsCourse =
       typeof decodeSearchQueryLabel(queries[0]).prefix !== 'undefined';
@@ -70,6 +71,7 @@ export default async function Page({ searchParams }: Props) {
       </>
     );
   }
+  searchTerms = decodeURIComponent(searchTerms);
 
   const decodedSearchTerms = searchTerms.split(',').map(decodeSearchQueryLabel);
   const courses = decodedSearchTerms.filter(

--- a/src/types/SearchQuery.tsx
+++ b/src/types/SearchQuery.tsx
@@ -121,7 +121,9 @@ export function searchQueryEqual(
 }
 
 export function decodeSearchQueryLabel(encodedSearchTerm: string): SearchQuery {
-  const encodedSearchTermParts = encodedSearchTerm.split(' ');
+  const encodedSearchTermParts = decodeURIComponent(encodedSearchTerm)
+    .replaceAll('+', ' ')
+    .split(' ');
   // Does it start with prefix
   if (/^([A-Z]{2,4})$/.test(encodedSearchTermParts[0])) {
     // If it is just the prefix, return that


### PR DESCRIPTION
In a URL " " is replaced with "+" and in URL encoding "+" is replaced with "%2B" which we were not accounting for:

http://dev.trends.utdnebula.com/dashboard?searchTerms=MATH%2B2413
https://utd-trends-git-url-encoding-fix-utdnebula.vercel.app/dashboard?searchTerms=MATH%2B2413

This PR uses `decodeURIComponent` to convert convert an extra percent encoding back to "+", ",", etc.