### PR TITLE
Docs example

### DIFF
--- a/src/app/SharedStateProvider.tsx
+++ b/src/app/SharedStateProvider.tsx
@@ -86,7 +86,7 @@ export function SharedStateProvider({
     [key: string]: GenericFetchedData<Grades>;
   }>({});
   const compareGradesRef = useRef(compareGrades);
-  //Uupdate ref for setGrades
+  //Update ref for setGrades
   const setCompareGrades = useCallback(
     (value: SetterValue<{ [key: string]: GenericFetchedData<Grades> }>) => {
       internalSetCompareGrades((prev) => {

--- a/src/components/DocsWrapper.tsx
+++ b/src/components/DocsWrapper.tsx
@@ -1,0 +1,18 @@
+import { ThemeProvider } from '@mui/material/styles';
+import React from 'react';
+
+import { SharedStateProvider } from '@/app/SharedStateProvider';
+import theme from '@/modules/theme';
+
+// Wrapper to inject types and state into Styleguidist docs
+// Basically a simplified version of layout.tsx
+
+export default function DocsWrapper({ children }: React.PropsWithChildren) {
+  return (
+    <div className="bg-white dark:bg-black text-haiti dark:text-white">
+      <ThemeProvider theme={theme}>
+        <SharedStateProvider>{children}</SharedStateProvider>
+      </ThemeProvider>
+    </div>
+  );
+}

--- a/src/components/navigation/Carousel/README.md
+++ b/src/components/navigation/Carousel/README.md
@@ -3,24 +3,27 @@ It uses the `framer-motion` library to provide sliding carousel animations when 
 
 ### Props Table
 
-| Prop            | Type               | Description                                                    | Required |
-| :-------------- | :----------------- | :------------------------------------------------------------- | -------- |
-| `names`         | `string, string[]` | The name(s) of the children element(s)                         | Yes      |
-| `children`      | `React.ReactNode`  | The element(s) that will be rendered in the carousel           | Yes      |
-| `compareLength` | `number`           | The number of element(s) that will be rendered in the carousel | Yes      |
+| Prop       | Type              | Description                                                 | Required |
+| :--------- | :---------------- | :---------------------------------------------------------- | -------- |
+| `names`    | `React.ReactNode` | The name(s) of the tabs, can be strings or react components | Yes      |
+| `children` | `React.ReactNode` | The element(s) that will be rendered in the carousel        | Yes      |
 
 ### Carousel Example
 
 ```tsx
-<Carousel names = { ['Tab 1', 'Tab 2']}>
-    <div > Content for Tab 1 < /div>
+import { useSharedState } from '@/app/SharedStateProvider';
+const ShardStateSetter = () => {
+  const { addToCompare } = useSharedState();
+  React.useEffect(() => {
+    addToCompare({ profFirst: 'John', profLast: 'Cole' });
+  }, []);
+  return null;
+};
+<>
+  <ShardStateSetter />
+  <Carousel names={['Tab 1', 'Tab 2']}>
+    <div>Content for Tab 1</div>
     <div>Content for Tab 2</div>
-</Carousel>
-```
-
-```tsx
-<Carousel names={['Tab 1', 'Tab 2']} compareLength={1}>
-  <div>Content for Tab 1</div>
-  <div>Content for Tab 2</div>
-</Carousel>
+  </Carousel>
+</>;
 ```

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -5,6 +5,9 @@ const dotenv = require('dotenv').config({ path: __dirname + '/.env' });
 module.exports = {
   pagePerSection: true,
   title: 'UTD Trends Documentation',
+  styleguideComponents: {
+    Wrapper: path.join(__dirname, './src/components/DocsWrapper.tsx'),
+  },
   template: {
     links: [
       {


### PR DESCRIPTION
Since using `useContext` to pass data around in Next.js's app router, Styleguidist has been all messed up.

This adds a wrapper that gives all Styleguidist components access to that context (and to the MUI theme) and fixes one component to be a working example.

<img width="2255" height="1251" alt="image" src="https://github.com/user-attachments/assets/8bb55828-4e6a-4eaf-86ac-fedb855b0d7c" />

After merge, #182 should be updated to reflect `src\components\navigation\Carousel\README.md` being the example to look at. Maybe we even ought to split that up into a bunch of small good first issues.