### PR TITLE
SV Randall fix

### DIFF
--- a/src/components/overview/ProfessorOverview/ProfessorOverview.tsx
+++ b/src/components/overview/ProfessorOverview/ProfessorOverview.tsx
@@ -3,7 +3,7 @@
 import { Skeleton } from '@mui/material';
 import Image from 'next/image';
 import Link from 'next/link';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import SingleGradesInfo, {
   LoadingSingleGradesInfo,
@@ -48,9 +48,13 @@ export default function ProfessorOverview({
   grades,
   rmp,
 }: Props) {
+  // State used to force image reload when src changes on navigation to new prof
   const [src, setSrc] = useState(
     profData.message === 'success' ? profData.data.image_uri : '',
   );
+  useEffect(() => {
+    setSrc(profData.message === 'success' ? profData.data.image_uri : '');
+  }, [profData]);
 
   return (
     <div className="flex flex-col gap-2">

--- a/src/types/SearchQuery.tsx
+++ b/src/types/SearchQuery.tsx
@@ -125,7 +125,13 @@ export function decodeSearchQueryLabel(encodedSearchTerm: string): SearchQuery {
     .replaceAll('+', ' ')
     .split(' ');
   // Does it start with prefix
-  if (/^([A-Z]{2,4})$/.test(encodedSearchTermParts[0])) {
+  if (
+    /^([A-Z]{2,4})$/.test(encodedSearchTermParts[0]) &&
+    // If it has only 2 parts, make sure the second is a course number
+    // Otherwise the name SV Randall will decode as { prefix: 'SV', profFirst: '', profLast: 'Randall' }
+    (encodedSearchTermParts.length != 2 ||
+      /^([0-9A-Z]{4})$/.test(encodedSearchTermParts[1]))
+  ) {
     // If it is just the prefix, return that
     if (encodedSearchTermParts.length == 1) {
       return { prefix: encodedSearchTermParts[0] };


### PR DESCRIPTION
There's an application error on https://trends.utdnebula.com/dashboard?searchTerms=SV+Randall because the name SV Randall decodes as `{ prefix: 'SV', profFirst: '', profLast: 'Randall' }` since SV looks like a prefix. Fixed with a check to make sure there's either enough parts to decode a prefix, number, and name or its just a prefix and number.

Also when I upgraded to Next.js app router I think I messed up a fix that Abhriram made to make sure the professor photo changes when you search up a new professor so I added that back. I can't find the PR but it was similar to this one: https://github.com/UTDNebula/website-v2/pull/80