### PR TITLE
Prevent being able to check checkboxes in the tutorial

### DIFF
--- a/src/components/dashboard/Tutorial/Tutorial.tsx
+++ b/src/components/dashboard/Tutorial/Tutorial.tsx
@@ -137,13 +137,13 @@ const stepsTemplate: StepTemplate[] = [
       <>
         <p>Open a result for more detailed information.</p>
         <div className="flex items-center">
-          <Checkbox />
+          <Checkbox checked={false} />
           <p>
             add an item to the <b>compare</b> tab.
           </p>
         </div>
         <div className="flex items-center">
-          <Checkbox icon={<BookOutlinedIcon />} />
+          <Checkbox icon={<BookOutlinedIcon />}  checked={false} />
           <p>
             add an item to the <b>My Planner</b> page.
           </p>

--- a/src/components/dashboard/Tutorial/Tutorial.tsx
+++ b/src/components/dashboard/Tutorial/Tutorial.tsx
@@ -143,7 +143,7 @@ const stepsTemplate: StepTemplate[] = [
           </p>
         </div>
         <div className="flex items-center">
-          <Checkbox icon={<BookOutlinedIcon />}  checked={false} />
+          <Checkbox icon={<BookOutlinedIcon />} checked={false} />
           <p>
             add an item to the <b>My Planner</b> page.
           </p>


### PR DESCRIPTION
## Overview

Prevents this as the boxes are just for visualization

https://github.com/user-attachments/assets/f16bda9a-d144-4aa7-a1dd-91be2766acbc

## What Changed

Added `checked={false}` to make the checkboxes controlled.
