### PR TITLE
Issue 483: Adding Undefined GPA to Compare Crashes Out

### DIFF
--- a/src/components/compare/CompareTable/CompareTable.tsx
+++ b/src/components/compare/CompareTable/CompareTable.tsx
@@ -154,7 +154,9 @@ function GradeOrRmpRow<T>({
           {((typeof value === 'undefined' || value.message !== 'success') && (
             <></>
           )) ||
-            (value.message === 'success' && getValue(value.data) !== -1 && getValue(value.data) !== undefined ? (
+            (value.message === 'success' &&
+            getValue(value.data) !== -1 &&
+            getValue(value.data) !== undefined ? (
               (name !== 'GPA' ? (value.data as RMP).numRatings > 0 : true) && ( // do not display RMP data (non-GPA data) if there are no reviews
                 <Tooltip
                   title={`${name}: ${formatValue(getValue(value.data))}`}

--- a/src/components/compare/CompareTable/CompareTable.tsx
+++ b/src/components/compare/CompareTable/CompareTable.tsx
@@ -154,7 +154,7 @@ function GradeOrRmpRow<T>({
           {((typeof value === 'undefined' || value.message !== 'success') && (
             <></>
           )) ||
-            (value.message === 'success' && getValue(value.data) !== -1 ? (
+            (value.message === 'success' && getValue(value.data) !== -1 && getValue(value.data) !== undefined ? (
               (name !== 'GPA' ? (value.data as RMP).numRatings > 0 : true) && ( // do not display RMP data (non-GPA data) if there are no reviews
                 <Tooltip
                   title={`${name}: ${formatValue(getValue(value.data))}`}


### PR DESCRIPTION
Implemented quick conditional to prevent fully undefined gpa from crashing website. For example, all withdraws in 2V90.