### PR TITLE
Compare components docs

### DIFF
--- a/src/components/compare/Compare/README.md
+++ b/src/components/compare/Compare/README.md
@@ -1,0 +1,181 @@
+This component allows different courses to be compared with 3 different components: a CompareTable, a LineGraph, and a BarGraph. If the 'Add to Compare' button is clicked on search results, the course gets added to the 'Compare' tab on the right. Each component shows data from two or more search queries side-by-side.
+
+### Compare Example
+
+```jsx
+// code is basically a combination of sample code from common/SingleGradesInfo and compare/CompareTable
+
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Skeleton,
+} from '@mui/material';
+import React from 'react';
+import TableSortLabel from '@/components/common/TableSortLabel/TableSortLabel';
+import BarGraph from '@/components/graph/BarGraph/BarGraph';
+import LineGraph from '@/components/graph/LineGraph/LineGraph';
+import GraphToggle from '@/components/navigation/GraphToggle/GraphToggle';
+
+// code from CompareTable
+const SampleProps = {
+  name: [
+    'GPA',
+    'Rating',
+    'Would Take Again',
+    'Difficulty',
+    '# of Grades / Ratings',
+    'Color',
+  ],
+  colors: ['#0e60e6', '#e60e2e'],
+};
+
+function RowStart(props) {
+  return (
+    <>
+      <TableCell
+        key={props.title}
+        className="text-center py-3 border-x-2 border-t-2 rounded-t-lg w-min"
+        sx={{ borderBottom: 'none' }}
+        style={{
+          borderColor: props.color,
+          backgroundColor: props.color + '10', // add transparency
+        }}
+      >
+        {props.title}
+      </TableCell>
+    </>
+  );
+}
+
+function GradeOrRmpRow(props) {
+  return (
+    <>
+      <TableRow sx={{ '& td': { border: 0 } }}>
+        <TableCell align="right" className="pl-0">
+          <TableSortLabel
+            active={true}
+            direction={'asc'}
+            sx={
+              props.title == '# of Grades / Ratings'
+                ? { '& .MuiTableSortLabel-icon': { display: 'none' } }
+                : props.title == 'Difficulty'
+                  ? {
+                      '& .MuiTableSortLabel-icon': { rotate: '90deg' },
+                    }
+                  : {
+                      '& .MuiTableSortLabel-icon': { rotate: '-90deg' },
+                    }
+            }
+          >
+            {
+              <Tooltip
+                title={props.title}
+                placement="left"
+                PopperProps={{
+                  modifiers: [
+                    {
+                      name: 'offset',
+                      options: {
+                        offset: [0, 10], // Adjust these values as needed
+                      },
+                    },
+                  ],
+                }}
+              >
+                <span>{props.title}</span>
+              </Tooltip>
+            }
+          </TableSortLabel>
+        </TableCell>
+        {SampleProps.colors.map((c, idx) => (
+          <TableCell
+            key={idx}
+            className={
+              props.title != 'Color'
+                ? 'py-3 border-x-2'
+                : 'pt-0 pb-1 border-x-2 border-b-2 rounded-b-lg'
+            }
+            style={{
+              borderColor: c,
+              backgroundColor: c + '10', // small transparency
+            }}
+          />
+        ))}
+      </TableRow>
+    </>
+  );
+}
+
+// end of code from CompareTable
+
+// code from SingleGradesInfo
+const sampleSeries = [
+  {
+    name: 'Sample Course',
+    data: [],
+  },
+];
+const barNode = (
+  <BarGraph
+    series={sampleSeries}
+    yaxisFormatter={(value) => Number(value).toFixed(0).toLocaleString() + '%'}
+    xaxisLabels={[
+      'A+',
+      'A',
+      'A-',
+      'B+',
+      'B',
+      'B-',
+      'C+',
+      'C',
+      'C-',
+      'D+',
+      'D',
+      'D-',
+      'F',
+      'W',
+    ]}
+    title="% of Students"
+  ></BarGraph>
+);
+const lineNode = (
+  <LineGraph title="GPA Trend" series={sampleSeries}></LineGraph>
+);
+// end of code from SingleGradesInfo
+
+<>
+  <div className="w-full py-5">
+    {/* Code from SingleGradesInfo (only one line) */}
+    <GraphToggle state="ready" bar={barNode} line={lineNode} />
+
+    {/* Code from CompareTable */}
+    <TableContainer className="w-fit h-full mb-4">
+      <Table size="small" className="border-spacing-x-2 border-separate">
+        <TableHead>
+          <TableRow>
+            <TableCell
+              className="font-bold px-0 text-center"
+              sx={{ borderBottom: 'none' }}
+            >
+              Compare
+            </TableCell>
+            <RowStart title="Sample Class #1" color={SampleProps.colors[0]} />
+            <RowStart title="Sample Class #2" color={SampleProps.colors[1]} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {SampleProps.name.map((col) => (
+            <GradeOrRmpRow title={col} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  </div>
+</>;
+```

--- a/src/components/compare/Compare/README.md
+++ b/src/components/compare/Compare/README.md
@@ -35,6 +35,7 @@ const SampleProps = {
   colors: ['#0e60e6', '#e60e2e'],
 };
 
+// Makes a colored rectangle that holds all the data for a SearchQuery
 function RowStart(props) {
   return (
     <>
@@ -53,6 +54,7 @@ function RowStart(props) {
   );
 }
 
+// Shows the categories to the left and finishes the border for each SearchQuery
 function GradeOrRmpRow(props) {
   return (
     <>
@@ -121,6 +123,7 @@ const sampleSeries = [
     data: [],
   },
 ];
+// empty bar graph
 const barNode = (
   <BarGraph
     series={sampleSeries}
@@ -144,6 +147,7 @@ const barNode = (
     title="% of Students"
   ></BarGraph>
 );
+// empty line graph
 const lineNode = (
   <LineGraph title="GPA Trend" series={sampleSeries}></LineGraph>
 );
@@ -152,9 +156,11 @@ const lineNode = (
 <>
   <div className="w-full py-5">
     {/* Code from SingleGradesInfo (only one line) */}
+    {/* Shows a sample with an empty bar graph and line graph */}
     <GraphToggle state="ready" bar={barNode} line={lineNode} />
 
     {/* Code from CompareTable */}
+    {/* Shows a sample with 2 classes */}
     <TableContainer className="w-fit h-full mb-4">
       <Table size="small" className="border-spacing-x-2 border-separate">
         <TableHead>

--- a/src/components/compare/CompareTable/README.md
+++ b/src/components/compare/CompareTable/README.md
@@ -38,6 +38,7 @@ const SampleProps = {
   colors: ['#0e60e6', '#e60e2e'],
 };
 
+// Makes a colored rectangle that holds all the data for a SearchQuery
 function RowStart(props) {
   return (
     <>
@@ -56,6 +57,7 @@ function RowStart(props) {
   );
 }
 
+// Shows the categories to the left and finishes the border for each SearchQuery
 function GradeOrRmpRow(props) {
   return (
     <>
@@ -116,6 +118,7 @@ function GradeOrRmpRow(props) {
 }
 
 <>
+  {/* Shows a sample with 2 classes */}
   <div className="w-full py-5">
     <TableContainer className="w-fit h-full mb-4">
       <Table size="small" className="border-spacing-x-2 border-separate">

--- a/src/components/compare/CompareTable/README.md
+++ b/src/components/compare/CompareTable/README.md
@@ -1,3 +1,143 @@
-```ts
-<CompareTable />
+This component shows a comparison between different courses. It is part of the Compare component and compares one or more courses based on average GPA, professor rating, percentage of students who would take the professor again, and the difficulty of the professor. It also allows the order of the courses to change (can be ordered based on the 4 categories listed above in either ascending or descending order). Courses can also be removed by de-selecting the checkbox.
+
+### Props Table
+
+| Prop                | Type                                        | Description                                                                           | Required |
+| :------------------ | :------------------------------------------ | :------------------------------------------------------------------------------------ | -------- |
+| `includedResults`   | `SearchQuery[]`                             | The search queries that are used for comparing (for ex. 'GOVT 2306' or 'Euel Elliot') | Yes      |
+| `grades`            | `[key: string]: GenericFetchedData<Grades>` | A mapping of grade data for each search query                                         | Yes      |
+| `rmp`               | `[key: string]: GenericFetchedData<RMP>`    | A mapping of RateMyProfessor data for each search query                               | Yes      |
+| `removeFromCompare` | `function with (arg0: SearchQuery)`         | Defines the function for removing a search query from the compare section             | Yes      |
+| `colorMap`          | `[key: string]: string`                     | A mapping of a color to each course for comparison purposes                           | Yes      |
+
+### CompareTable Example
+
+```jsx
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+} from '@mui/material';
+import React, { useState } from 'react';
+import TableSortLabel from '@/components/common/TableSortLabel/TableSortLabel';
+
+const SampleProps = {
+  name: [
+    'GPA',
+    'Rating',
+    'Would Take Again',
+    'Difficulty',
+    '# of Grades / Ratings',
+    'Color',
+  ],
+  colors: ['#0e60e6', '#e60e2e'],
+};
+
+function RowStart(props) {
+  return (
+    <>
+      <TableCell
+        key={props.title}
+        className="text-center py-3 border-x-2 border-t-2 rounded-t-lg w-min"
+        sx={{ borderBottom: 'none' }}
+        style={{
+          borderColor: props.color,
+          backgroundColor: props.color + '10', // add transparency
+        }}
+      >
+        {props.title}
+      </TableCell>
+    </>
+  );
+}
+
+function GradeOrRmpRow(props) {
+  return (
+    <>
+      <TableRow sx={{ '& td': { border: 0 } }}>
+        <TableCell align="right" className="pl-0">
+          <TableSortLabel
+            active={true}
+            direction={'asc'}
+            sx={
+              props.title == '# of Grades / Ratings'
+                ? { '& .MuiTableSortLabel-icon': { display: 'none' } }
+                : props.title == 'Difficulty'
+                  ? {
+                      '& .MuiTableSortLabel-icon': { rotate: '90deg' },
+                    }
+                  : {
+                      '& .MuiTableSortLabel-icon': { rotate: '-90deg' },
+                    }
+            }
+          >
+            {
+              <Tooltip
+                title={props.title}
+                placement="left"
+                PopperProps={{
+                  modifiers: [
+                    {
+                      name: 'offset',
+                      options: {
+                        offset: [0, 10], // Adjust these values as needed
+                      },
+                    },
+                  ],
+                }}
+              >
+                <span>{props.title}</span>
+              </Tooltip>
+            }
+          </TableSortLabel>
+        </TableCell>
+        {SampleProps.colors.map((c, idx) => (
+          <TableCell
+            key={idx}
+            className={
+              props.title != 'Color'
+                ? 'py-3 border-x-2'
+                : 'pt-0 pb-1 border-x-2 border-b-2 rounded-b-lg'
+            }
+            style={{
+              borderColor: c,
+              backgroundColor: c + '10', // small transparency
+            }}
+          />
+        ))}
+      </TableRow>
+    </>
+  );
+}
+
+<>
+  <div className="w-full py-5">
+    <TableContainer className="w-fit h-full mb-4">
+      <Table size="small" className="border-spacing-x-2 border-separate">
+        <TableHead>
+          <TableRow>
+            <TableCell
+              className="font-bold px-0 text-center"
+              sx={{ borderBottom: 'none' }}
+            >
+              Compare
+            </TableCell>
+            <RowStart title="Sample Class #1" color={SampleProps.colors[0]} />
+            <RowStart title="Sample Class #2" color={SampleProps.colors[1]} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {SampleProps.name.map((col) => (
+            <GradeOrRmpRow title={col} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  </div>
+</>;
 ```


### PR DESCRIPTION
## Overview

Resolves #495 

I made documentation changes to the Compare components: Compare and CompareTable. Both components now have some description, some props listed (if they were needed), and some sample code. This PR should help with using the Compare components in future features.

## What Changed

Added: @\src\components\compare\Compare\README.md and @\src\components\compare\CompareTable\README.md

Both files contain the documentation in markup. The code itself is in JSX. The documentation+code shows up on localhost:6060 when running `npm run docs`. 