### PR TITLE
Add availability=true to canonical

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -65,7 +65,8 @@ export async function generateMetadata({
             decodedSearchTerms
               .toSorted(searchQuerySort)
               .map((term) => searchQueryLabel(term).split(' ').join('+'))
-              .join(',')
+              .join(',') +
+            '&availability=true'
           : ''),
     },
   };


### PR DESCRIPTION
We're getting a lot of unindexed pages in the Google Search Console because the sitemap includes `availability=true` in the URL but the canonical tag does not.

<img width="1531" height="1014" alt="image" src="https://github.com/user-attachments/assets/59475a8c-fa0a-4508-9248-f69f20af59d3" />



General indexing does look good tho:

<img width="1567" height="686" alt="image" src="https://github.com/user-attachments/assets/74f7b90c-5b24-4e5b-929f-dee3bddf04b8" />
