### PR TITLE
[Feature Request] Add to Planner from Compare #473

### DIFF
--- a/src/components/compare/CompareTable/CompareTable.tsx
+++ b/src/components/compare/CompareTable/CompareTable.tsx
@@ -271,16 +271,20 @@ function GradeAndRmpRow({
     </TableRow>
   );
 }
-type CheckboxRowProps = {
+
+type PlannerRowProps = {
   name: string;
   courses: SearchResult[];
-  removeFromCompare?: (arg0: SearchResult) => void;
   cell_className: string;
   colors: string[];
   orderBy: string;
   order: 'asc' | 'desc';
-  handleClick?: (arg0: string) => void;
 };
+type CheckboxRowProps = PlannerRowProps & {
+  removeFromCompare: (arg0: SearchResult) => void;
+  handleClick: (arg0: string) => void;
+};
+
 // This is for checkboxes to remove courses from the compare table
 function CheckboxRow({
   name,
@@ -299,11 +303,7 @@ function CheckboxRow({
           active={orderBy === name}
           direction={orderBy === name ? order : 'desc'}
           onClick={() => {
-            if (handleClick) {
-              handleClick(name);
-            } else {
-              console.log('Error, handleClick not specified');
-            }
+            handleClick(name);
           }}
           sx={{
             '& .MuiTableSortLabel-icon': {
@@ -328,13 +328,7 @@ function CheckboxRow({
             <Checkbox
               checked={true}
               onClick={() => {
-                if (removeFromCompare) {
-                  removeFromCompare(course);
-                } else {
-                  console.log(
-                    'Error, removeFromCompare function not specified!',
-                  );
-                }
+                removeFromCompare(course);
               }}
               sx={{
                 '&.Mui-checked': {
@@ -354,7 +348,7 @@ function PlannerRow({
   courses,
   cell_className, // for specifying border mostly
   colors, // border colors
-}: CheckboxRowProps) {
+}: PlannerRowProps) {
   return (
     <TableRow sx={{ '& td': { border: 0 } }}>
       <TableCell align="right" className="pl-0">


### PR DESCRIPTION
## Overview

List the GitHub issues containing the issues relevant to this pull request.

Resolves issue #473 - Added the functionality for adding to MyPlanner from Compare.

## What Changed

Created a separate component for the planner checkbox in @/components/common, as the same code was being reused for both the CompareTable.tsx file and the SearchResultsTable.tsx file. Then added a div wrapping the title of each course with the planner checkbox component so that flexbox could be employed. Created a separate row at the end for adding to planner functionality and moved the bookmark icon to the row. Created a custom component called PlannerRow, which used the same type as CheckboxRow. However, it did not include two functions: handleClick and removeFromCompare, hence those were made optional, and additional checks were added to ensure that an undefined function would not be called and functionality would remain the same. The PlannerRow component is slightly different from the CheckboxRow component, in that it no longer has a TableSortLabel, as this was redundant. Lastly, the functionality for the button was included in the PlannerRow.

## Other Notes

Media queries and breakpoints should be utilized, as the mobile view is difficult to read.