### PR TITLE
fix: planner course name tool tip missing

### DIFF
--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -471,7 +471,9 @@ export default function PlannerCard(props: PlannerCardProps) {
           <Tooltip
             title={
               typeof props.query.prefix !== 'undefined' &&
-              typeof props.query.number !== 'undefined'
+              typeof props.query.number !== 'undefined' &&
+              result.type !== 'professor' &&
+              result.courseName
             }
             placement="top"
           >


### PR DESCRIPTION
## Overview
Planner tooltips on course names were accidentally removed in the state refactor, this puts them back
