### PR TITLE
Remove search results divider bg color

### DIFF
--- a/src/components/search/SearchResultsTable/SearchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/SearchResultsTable.tsx
@@ -720,7 +720,7 @@ export default function SearchResultsTable({
 
             {/* Divider row */}
             {sortedUnIncludedResults.length > 0 && (
-              <TableRow className="bg-gray-200 dark:bg-gray-700">
+              <TableRow>
                 <TableCell colSpan={5} className="p-0">
                   <div className="flex items-center py-2 my-2">
                     <Divider className="grow" />


### PR DESCRIPTION
Remove the background on the divider between the combos being taught this semester and those not. Related to but not resolving #443.

<img width="2253" height="1254" alt="after" src="https://github.com/user-attachments/assets/e4e22404-29d2-4b4c-ac3d-ec8853d550ab" />

