### PR TITLE
fix: Search Filter Counts

### DIFF
--- a/src/components/search/Filters/Filters.tsx
+++ b/src/components/search/Filters/Filters.tsx
@@ -140,9 +140,11 @@ export default function Filters({
   const rmpCounts: Record<string, number> = {};
 
   const semFilteredResults = searchResults.filter((result) => {
-    const availableThisSemester = filterNextSem && result.sections.some(
-      (section) => section.academic_session.name === latestSemester,
-    );
+    const availableThisSemester =
+      filterNextSem &&
+      result.sections.some(
+        (section) => section.academic_session.name === latestSemester,
+      );
     return (
       result.grades.length == 0 ||
       result.grades.some((s) => chosenSemesters.includes(s._id)) ||


### PR DESCRIPTION
## Overview

Current Filter counts on 'rating' filter don't account for semesters filter, and founts on both filters don't include classes without grades/ratings, leading to some counts that look incorrect

## What Changed

Count only results that haven't been filtered out by the semesters filter, and count results that have no grade/rating data and are therefore not filtered out

## Other Notes
