### PR TITLE
Error catch when searching for course that does not exist

### DIFF
--- a/src/modules/createSearchQuery.ts
+++ b/src/modules/createSearchQuery.ts
@@ -17,14 +17,17 @@ export function createSearchQuery(
   filterTerms: SearchQuery[], //filterTerms is blank if the searchTerms are ALL courses or ALL professors
 ) {
   return searchTerms
-    .flatMap((searchTerm) =>
-      [searchTerm].concat(
+    .flatMap((searchTerm) => {
+      if (!(searchQueryLabel(searchTerm) in comboTable)) {
+        return [];
+      }
+      return [searchTerm].concat(
         comboTable[searchQueryLabel(searchTerm)].map((combo) => ({
           ...searchTerm,
           ...combo,
         })),
-      ),
-    )
+      );
+    })
     .filter(
       (searchTerm) =>
         !filterTerms.length ||


### PR DESCRIPTION
No more `Application error: a client-side exception has occurred (see the browser console for more information).` when putting a course that does not exist in the URL.

Instead it returns an empty array:
<img width="2255" height="1250" alt="image" src="https://github.com/user-attachments/assets/616b5b6f-8af8-44ea-a9ec-2bc124e308cb" />

Test: https://utd-trends-git-non-existant-course-fix-utdnebula.vercel.app/dashboard?searchTerms=CS+1201&availability=true