### PR TITLE
update next.js to fix new RCEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "google-auth-library": "^9.15.1",
         "graphology": "^0.26.0",
         "html2canvas-pro": "^1.5.11",
-        "next": "^15.5.4",
+        "next": "^15.5.9",
         "react": "^19.1.0",
         "react-apexcharts": "^1.7.0",
         "react-dom": "^19.1.1",
@@ -121,7 +121,6 @@
     "node_modules/@babel/core": {
       "version": "7.27.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1649,7 +1648,6 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1687,7 +1685,6 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2038,7 +2035,6 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
       "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.4",
@@ -2260,9 +2256,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
-      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2481,7 +2477,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2489,6 +2484,7 @@
     "node_modules/@opentelemetry/api-logs": {
       "version": "0.200.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -3908,6 +3904,7 @@
     "node_modules/@opentelemetry/resources": {
       "version": "2.0.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3938,7 +3935,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.34.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4082,7 +4078,6 @@
     "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4789,7 +4784,6 @@
     "node_modules/@svgdotjs/svg.js": {
       "version": "3.2.4",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Fuzzyma"
@@ -4809,7 +4803,6 @@
     "node_modules/@svgdotjs/svg.select.js": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.18"
       },
@@ -5222,7 +5215,6 @@
     "node_modules/@tanstack/react-query": {
       "version": "5.90.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.5"
       },
@@ -5436,7 +5428,6 @@
     "node_modules/@types/node": {
       "version": "22.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5487,7 +5478,6 @@
     "node_modules/@types/react": {
       "version": "19.1.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5571,7 +5561,8 @@
     "node_modules/@types/stylis": {
       "version": "4.2.5",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
@@ -5625,7 +5616,6 @@
       "version": "8.29.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.29.1",
         "@typescript-eslint/types": "8.29.1",
@@ -6048,7 +6038,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6104,7 +6093,6 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6201,7 +6189,6 @@
     "node_modules/apexcharts": {
       "version": "4.5.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@svgdotjs/svg.draggable.js": "^3.0.4",
         "@svgdotjs/svg.filter.js": "^3.0.8",
@@ -6689,7 +6676,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -6724,7 +6710,6 @@
       "version": "6.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6955,6 +6940,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7427,6 +7413,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7492,6 +7479,7 @@
       "version": "3.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -8195,7 +8183,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8367,7 +8354,6 @@
       "version": "2.31.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -11774,13 +11760,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
-      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@next/env": "15.5.7",
+        "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -12596,7 +12581,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -12968,7 +12952,6 @@
     "node_modules/react": {
       "version": "19.1.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13178,7 +13161,6 @@
     "node_modules/react-dom": {
       "version": "19.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -13677,7 +13659,6 @@
     "node_modules/rollup": {
       "version": "4.35.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -14058,7 +14039,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14294,7 +14274,8 @@
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sharp": {
       "version": "0.34.4",
@@ -15171,6 +15152,7 @@
       "version": "6.1.18",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
@@ -15198,6 +15180,7 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -15205,12 +15188,14 @@
     "node_modules/styled-components/node_modules/@emotion/memoize": {
       "version": "0.8.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/styled-components/node_modules/@emotion/unitless": {
       "version": "0.8.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/styled-components/node_modules/postcss": {
       "version": "8.4.49",
@@ -15230,6 +15215,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -15242,12 +15228,14 @@
     "node_modules/styled-components/node_modules/stylis": {
       "version": "4.3.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/styled-components/node_modules/tslib": {
       "version": "2.6.2",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -15662,7 +15650,6 @@
       "version": "5.8.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16019,7 +16006,6 @@
     "node_modules/webpack": {
       "version": "5.99.9",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "google-auth-library": "^9.15.1",
     "graphology": "^0.26.0",
     "html2canvas-pro": "^1.5.11",
-    "next": "^15.5.4",
+    "next": "^15.5.9",
     "react": "^19.1.0",
     "react-apexcharts": "^1.7.0",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
See [this](https://vercel.com/kb/bulletin/security-bulletin-cve-2025-55184-and-cve-2025-55183?inf_ver=2&inf_ctx=iWs_5UZHYW4A-9dbRUIKcM9Ibnp29XXXEh-M83BnkrXsL45pK2vNr_-V0eBYLxlSaj0fnF-VbF7oT1xNjqLdm8FRUnXogwcL1LzKfBgImJ45AUY1gryTZgIbgKA0c3G53qfBxjSSoBgkDb_YfH0HPntmYKlTlOMWXDEzdrdi5R7GKvn8aCjZFoPSOkkOSPIbSTuDN6o3XwqvjYGWG0t2i7ABGItzA9sVpUOrrZS1ZCZlwqAAcTkzA-eec9mGQgF8mynUxHrPOZMRGdFGDBqPUtOI4-jI5tnhyreow34izG9zBhOia-_YDPVbK4HI5AXOB2O6uO701v1QwpJbn5EzGg%3D%3D#patched-versions) blog post

"Following the [React2Shell](https://vercel.com/kb/bulletin/react2shell) disclosure, increased community research into React Server Components surfaced two additional vulnerabilities that require patching: a high-severity Denial of Service ([CVE-2025-55184](https://www.cve.org/CVERecord?id=CVE-2025-55184)) and a medium-severity Source Code Exposure ([CVE-2025-55183](https://www.cve.org/CVERecord?id=CVE-2025-55183)). They affect React 19 and frameworks that use it, like Next.js."
