### PR TITLE
fix: fix lint error by removing unnecessary import

### DIFF
--- a/src/app/Home.tsx
+++ b/src/app/Home.tsx
@@ -2,7 +2,6 @@
 
 import Background from '@/../public/background.png';
 import NebulaLogo from '@/components/icons/NebulaLogo/NebulaLogo';
-import { UTDTrendsLogoStandalone } from '@/components/icons/UTDTrendsLogo/UTDTrendsLogo';
 import PlannerButton from '@/components/planner/PlannerButton/PlannerButton';
 import SearchBar, {
   updateRecentSearches,


### PR DESCRIPTION
## Overview

I accidentally merged Remove Kickoff Ad (#561) into develop without merging in the new logo change from develop first, causing a lint error. This removes the unnecessary import and resolves that error.