### PR TITLE
Fix planner navigation when no search data exists

### DIFF
--- a/src/components/navigation/Header/HeaderChildren.tsx
+++ b/src/components/navigation/Header/HeaderChildren.tsx
@@ -141,7 +141,7 @@ function HeaderChildrenInner(props: HeaderProps) {
     href: props.isPlanner
       ? dashboardSearchTerms != null
         ? '/dashboard?' + dashboardSearchTerms
-        : '/dashboard?availability=true'
+        : '/'
       : '/planner',
     onClick: () =>
       !props.isPlanner


### PR DESCRIPTION
## Overview
Resolves #472 

## What Changed
When navigating from the planner, if there is no data stored in sessionStorage, users are redirected to the landing page instead of an empty dashboard.

