### PR TITLE
585: Exclude Pass/Fail sections from GPA calculations

### DIFF
--- a/src/components/graph/LineGraph/LineGraph.tsx
+++ b/src/components/graph/LineGraph/LineGraph.tsx
@@ -39,11 +39,11 @@ function getSemesterGPAs(
         (acc, section) => {
           if (
             (!chosenSectionTypes ||
-            chosenSectionTypes.length === 0 ||
-            chosenSectionTypes.includes(section.type)) &&
+              chosenSectionTypes.length === 0 ||
+              chosenSectionTypes.includes(section.type)) &&
             section.type !== 'Pass/Fail'
           ) {
-          return acc.map(
+            return acc.map(
               (v, i) => v + (section.grade_distribution?.[i] ?? 0),
             );
           }

--- a/src/modules/fetchGrades.ts
+++ b/src/modules/fetchGrades.ts
@@ -32,7 +32,7 @@ export function calculateGrades(
       for (const sectionData of session.data) {
         if (
           (typeof sectionTypes === 'undefined' ||
-          sectionTypes.includes(sectionData.type)) &&
+            sectionTypes.includes(sectionData.type)) &&
           sectionData.type !== 'Pass/Fail'
         ) {
           grade_distribution = grade_distribution.map(


### PR DESCRIPTION
## Description
Pass/Fail-only classes were incorrectly being included in GPA and line graph calculations.

## Changes
- Modified calculateGrades in fetchGrades.ts to exclude 'Pass/Fail' sections
- Modified getSemesterGPAs in LineGraph.tsx to exclude 'Pass/Fail' sections
