### PR TITLE
Undo Planner DownloadUI Change

### DIFF
--- a/src/app/planner/PlannerDownloadUI.tsx
+++ b/src/app/planner/PlannerDownloadUI.tsx
@@ -15,7 +15,7 @@ export default function PlannerDownloadUI({
 
   return (
     <div
-      className="bg-black p-4 absolute -left-[-9999px] top-0"
+      className="bg-black p-4 absolute -left-[9999px] top-0"
       ref={downloadRef}
     >
       <div className="flex flex-row mb-4 justify-start gap-2 pl-2 items-center">

--- a/src/components/navigation/Header/HeaderChildren.tsx
+++ b/src/components/navigation/Header/HeaderChildren.tsx
@@ -264,6 +264,15 @@ function HeaderChildrenInner(props: HeaderProps) {
         open={openMenu}
         anchorEl={menuAnchorEl}
         onClose={handleCloseMenu}
+        disableScrollLock={true}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
         slotProps={{
           list: {
             'aria-labelledby': 'header-menu-button',


### PR DESCRIPTION
Mobile planner UI was broken by trying to fix issue with DownloadUI
To fix both:
- make sure download UI is off the LEFT side of the page
- make sure mobile 3-dot menu doesn't go off the page by making it always drop down to the left of its anchor
- undo change to DownloadUI from #601 

Tested page + download on desktop and mobile; it seems to be working and not making the page jump around like it did before.