### PR TITLE
Search other professors in planner

### DIFF
--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -22,6 +22,7 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import BookIcon from '@mui/icons-material/Book';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import EventIcon from '@mui/icons-material/Event';
+import SearchIcon from '@mui/icons-material/Search';
 import KeyboardArrowIcon from '@mui/icons-material/KeyboardArrowRight';
 import {
   Box,
@@ -383,6 +384,7 @@ function SectionTableRow(props: SectionTableRowProps) {
 function SearchOtherProfessorFooter(props: {
   course: Course | Record<string, never>;
   teachingSemester: string;
+  bottomBorder: boolean;
 }) {
   const params = new URLSearchParams();
   if ('prefix' in props.course && 'number' in props.course) {
@@ -398,11 +400,19 @@ function SearchOtherProfessorFooter(props: {
     <TableRow>
       <TableCell
         colSpan={6}
-        className="py-1 border-t-1 border-t-royal dark:border-t-cornflower-300"
+        className={`
+          py-2 border-t border-t-royal dark:border-t-cornflower-300
+          ${
+            props.bottomBorder
+              ? 'border-b border-b-royal dark:border-b-cornflower-300'
+              : 'border-b-0'
+          }
+        `}
         align="center"
       >
         <Button
-          className="normal-case"
+          className="normal-case rounded-full"
+          variant='contained'
           LinkComponent={Link}
           href={`dashboard?${params.toString()}`}
           onClick={() => {
@@ -410,6 +420,7 @@ function SearchOtherProfessorFooter(props: {
             // instead of clicking "Search Results"
             sessionStorage.setItem('dashboardSearchTerms', params.toString());
           }}
+          startIcon={<SearchIcon />}
         >
           See other professors
         </Button>
@@ -789,6 +800,10 @@ export default function PlannerCard(props: PlannerCardProps) {
                 <SearchOtherProfessorFooter
                   course={convertToCourseOnly(props.query)}
                   teachingSemester={props.teachingSemester}
+                  bottomBorder={
+                    latestExtraSections !== null &&
+                    latestExtraSections.sections.length > 0
+                  }
                 />
               </TableFooter>
             </Table>

--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -2,6 +2,7 @@
 
 import SingleGradesInfo from '@/components/common/SingleGradesInfo/SingleGradesInfo';
 import SingleProfInfo from '@/components/common/SingleProfInfo/SingleProfInfo';
+import { setAvailabilitySemester } from '@/modules/availability';
 import { calculateGrades } from '@/modules/fetchGrades';
 import type { Sections, SectionsData } from '@/modules/fetchSections';
 import { useSearchResult } from '@/modules/plannerFetch';
@@ -388,18 +389,16 @@ function SearchOtherProfessorFooter(props: {
     typeof props.course.number != 'undefined' &&
     typeof props.course.prefix != 'undefined'
   ) {
-    params.set(
-      'searchTerms',
-      decodeURIComponent(
-        `${props.course.prefix}+${props.course.number}`,
-      ).replaceAll('+', ' '),
-    );
-    params.set('availability', props.teachingSemester);
+    const combo = `${props.course.prefix}+${props.course.number}`;
+    params.set('searchTerms', decodeURIComponent(combo).replaceAll('+', ' '));
+    setAvailabilitySemester(params, props.teachingSemester);
   }
   return (
     <TableRow>
-      <TableCell colSpan={6} className="py-0" align="right">
+      <TableCell colSpan={6} className="py-1" align="center">
         <Button
+          className="normal-case"
+          LinkComponent={Link}
           href={`dashboard?${params.toString()}`}
           onClick={() => {
             // User may navigates between pages

--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -385,23 +385,28 @@ function SearchOtherProfessorFooter(props: {
   teachingSemester: string;
 }) {
   const params = new URLSearchParams();
-  if (
-    typeof props.course.number != 'undefined' &&
-    typeof props.course.prefix != 'undefined'
-  ) {
-    const combo = `${props.course.prefix}+${props.course.number}`;
-    params.set('searchTerms', decodeURIComponent(combo).replaceAll('+', ' '));
+  if ('prefix' in props.course && 'number' in props.course) {
+    params.set(
+      'searchTerms',
+      decodeURIComponent(
+        `${props.course.prefix}+${props.course.number}`,
+      ).replaceAll('+', ' '),
+    );
     setAvailabilitySemester(params, props.teachingSemester);
   }
   return (
     <TableRow>
-      <TableCell colSpan={6} className="py-1" align="center">
+      <TableCell
+        colSpan={6}
+        className="py-1 border-t-1 border-t-royal dark:border-t-cornflower-300"
+        align="center"
+      >
         <Button
           className="normal-case"
           LinkComponent={Link}
           href={`dashboard?${params.toString()}`}
           onClick={() => {
-            // User may navigates between pages
+            // User might navigates between pages
             // instead of clicking "Search Results"
             sessionStorage.setItem('dashboardSearchTerms', params.toString());
           }}

--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -22,8 +22,8 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import BookIcon from '@mui/icons-material/Book';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import EventIcon from '@mui/icons-material/Event';
-import SearchIcon from '@mui/icons-material/Search';
 import KeyboardArrowIcon from '@mui/icons-material/KeyboardArrowRight';
+import SearchIcon from '@mui/icons-material/Search';
 import {
   Box,
   Button,
@@ -412,7 +412,7 @@ function SearchOtherProfessorFooter(props: {
       >
         <Button
           className="normal-case rounded-full"
-          variant='contained'
+          variant="contained"
           LinkComponent={Link}
           href={`dashboard?${params.toString()}`}
           onClick={() => {

--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -12,6 +12,7 @@ import {
   removeSection,
   searchQueryLabel,
   sectionCanOverlap,
+  type Course,
   type SearchQuery,
   type SearchQueryMultiSection,
   type SearchResult,
@@ -23,6 +24,7 @@ import EventIcon from '@mui/icons-material/Event';
 import KeyboardArrowIcon from '@mui/icons-material/KeyboardArrowRight';
 import {
   Box,
+  Button,
   Checkbox,
   Collapse,
   IconButton,
@@ -33,6 +35,7 @@ import {
   TableBody,
   TableCell,
   TableContainer,
+  TableFooter,
   TableHead,
   TableRow,
   ToggleButton,
@@ -371,6 +374,41 @@ function SectionTableRow(props: SectionTableRowProps) {
             ''
           )}
         </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function SearchOtherProfessorFooter(props: {
+  course: Course | Record<string, never>;
+  teachingSemester: string;
+}) {
+  const params = new URLSearchParams();
+  if (
+    typeof props.course.number != 'undefined' &&
+    typeof props.course.prefix != 'undefined'
+  ) {
+    params.set(
+      'searchTerms',
+      decodeURIComponent(
+        `${props.course.prefix}+${props.course.number}`,
+      ).replaceAll('+', ' '),
+    );
+    params.set('availability', props.teachingSemester);
+  }
+  return (
+    <TableRow>
+      <TableCell colSpan={6} className="py-0" align="right">
+        <Button
+          href={`dashboard?${params.toString()}`}
+          onClick={() => {
+            // User may navigates between pages
+            // instead of clicking "Search Results"
+            sessionStorage.setItem('dashboardSearchTerms', params.toString());
+          }}
+        >
+          See other professors
+        </Button>
       </TableCell>
     </TableRow>
   );
@@ -743,6 +781,12 @@ export default function PlannerCard(props: PlannerCardProps) {
                   />
                 ))}
               </TableBody>
+              <TableFooter>
+                <SearchOtherProfessorFooter
+                  course={convertToCourseOnly(props.query)}
+                  teachingSemester={props.teachingSemester}
+                />
+              </TableFooter>
             </Table>
           </TableContainer>
           {/* Unassigned Professor Sections -- only show for a non-overall card */}


### PR DESCRIPTION
## Overview

Resolves #440,

Add the new footer at the bottom of the section planner card that allow for searching for other professors of the same given course. 

<img width="587" height="231" alt="Screenshot 2026-04-17 at 20 20 00" src="https://github.com/user-attachments/assets/eac59751-ef36-406c-9ba5-ffd3f9e98f2f" />

## What Changed
Add the footer at the bottom of list of available sections when the user expands. When the user clicks on the button, it will navigate to the page listing other professors of the course. 

My concern is that I'm not sure if this should be a button or a link, so some feedback would be great.
