### PR TITLE
Use skeletons for loading & refactor all loading pages

### DIFF
--- a/src/app/(home)/loading.tsx
+++ b/src/app/(home)/loading.tsx
@@ -2,7 +2,7 @@ import Background from '@/../public/background.png';
 import NebulaLogo from '@/components/icons/NebulaLogo/NebulaLogo';
 import PlannerButton from '@/components/planner/PlannerButton/PlannerButton';
 import { LoadingSearchBar } from '@/components/search/SearchBar/SearchBar';
-import { FormControl, FormControlLabel, Switch, Tooltip } from '@mui/material';
+import { Skeleton } from '@mui/material';
 import Image from 'next/image';
 import React from 'react';
 
@@ -18,7 +18,9 @@ export default function Loading() {
         fill
         className="object-cover -z-20"
       />
-      <PlannerButton className="absolute top-4 right-4" />
+      <div className="absolute top-4 left-4 right-4 flex gap-2 place-content-between flex-wrap-reverse">
+        <PlannerButton className="ml-auto" />
+      </div>
       <div className="max-w-xl grow flex flex-col justify-center">
         <h2 className="text-sm font-semibold mb-3 text-royal dark:text-cornflower-300 tracking-wider flex gap-1 items-center">
           <span className="leading-none">POWERED BY</span>
@@ -41,15 +43,14 @@ export default function Loading() {
           find the perfect class.
         </p>
         <LoadingSearchBar input_className="[&>.MuiInputBase-root]:bg-white dark:[&>.MuiInputBase-root]:bg-haiti" />
-        {/* Teaching Next Semester switch*/}
-        <Tooltip title="Select Availability" placement="bottom-start">
-          <FormControl size="small" className="min-w-max flex-row items-center">
-            <FormControlLabel
-              control={<Switch checked disabled />}
-              label="Teaching Next Semester"
-            />
-          </FormControl>
-        </Tooltip>
+        {/* Matches TeachingSemesterSelector on Home (Teaching in + semester) */}
+        <div className="mt-4 flex w-full flex-wrap items-center gap-2">
+          <Skeleton variant="rounded" className="h-[38px] w-[140px]" />
+          <Skeleton
+            variant="rounded"
+            className="h-10 min-w-[160px] flex-1 sm:flex-none"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -2,5 +2,8 @@ import React from 'react';
 import Home from './Home';
 
 export default async function Page() {
+  if (process.env.NEXT_PUBLIC_DEBUG_LOADING === '1') {
+    await new Promise<void>((resolve) => setTimeout(resolve, 30_000));
+  }
   return <Home />;
 }

--- a/src/app/dashboard/FilterContext.tsx
+++ b/src/app/dashboard/FilterContext.tsx
@@ -7,6 +7,7 @@ import {
 import type { SearchResult } from '@/types/SearchQuery';
 import {
   createContext,
+  useEffect,
   useMemo,
   useState,
   type Dispatch,
@@ -53,17 +54,14 @@ export default function FiltersProvider({
     getSectionTypesFromSearchResults(searchResults),
   );
 
-  const [prevSearchResults, setPrevSearchResults] =
-    useState<SearchResult[]>(searchResults);
-  if (searchResults != prevSearchResults) {
-    setPrevSearchResults(searchResults);
+  useEffect(() => {
     setChosenSemesters(
       getSemestersFromSearchResults(searchResults.concat(compare)),
     );
     setChosenSectionTypes(
       getSectionTypesFromSearchResults(searchResults.concat(compare)),
     );
-  }
+  }, [searchResults, compare]);
 
   return (
     <FiltersContext.Provider

--- a/src/app/dashboard/Right.tsx
+++ b/src/app/dashboard/Right.tsx
@@ -12,9 +12,17 @@ import fetchGrades from '@/modules/fetchGrades';
 import fetchProfessor from '@/modules/fetchProfessor';
 import fetchRmp from '@/modules/fetchRmp';
 import { type SearchQuery, type SearchResult } from '@/types/SearchQuery';
-import { Card } from '@mui/material';
-import React, { Suspense } from 'react';
+import { Card, Skeleton } from '@mui/material';
+import React from 'react';
 import ServerLeft from './ServerLeft';
+
+export function LoadingCompare() {
+  return (
+    <div className="p-4">
+      <Skeleton variant="rounded" className="h-56 w-full" />
+    </div>
+  );
+}
 
 interface LoadingRightProps {
   courses?: SearchQuery[];
@@ -50,7 +58,7 @@ export function LoadingRight(props: LoadingRightProps) {
 
   if (!props.isMobile) {
     names.push('Compare');
-    tabs.push(<Compare key="compare" />);
+    tabs.push(<LoadingCompare key="compare" />);
   }
 
   return (
@@ -82,13 +90,12 @@ export default async function Right(props: Props) {
   if (props.isMobile) {
     names.push('Search');
     tabs.push(
-      <Suspense key="search-results" fallback={<LoadingSearchResultsTable />}>
-        <ServerLeft
-          courses={props.courses}
-          professors={props.professors}
-          searchResultsPromise={props.searchResultsPromise}
-        />
-      </Suspense>,
+      <ServerLeft
+        key="search-results"
+        courses={props.courses}
+        professors={props.professors}
+        searchResultsPromise={props.searchResultsPromise}
+      />,
     );
   }
 

--- a/src/app/dashboard/ServerLeft.tsx
+++ b/src/app/dashboard/ServerLeft.tsx
@@ -1,6 +1,5 @@
-import { LoadingSearchResultsTable } from '@/components/search/SearchResultsTable/SearchResultsTable';
 import { type SearchQuery, type SearchResult } from '@/types/SearchQuery';
-import React, { Suspense } from 'react';
+import React from 'react';
 import ClientLeft from './ClientLeft';
 
 interface Props {
@@ -12,17 +11,11 @@ interface Props {
 /**
  * Returns the left side
  */
-export default async function ServerLeft(props: Props) {
-  // gets what are search results should be WITHOUT the associated data
-
+export default function ServerLeft(props: Props) {
   return (
-    <>
-      <Suspense fallback={<LoadingSearchResultsTable />}>
-        <ClientLeft
-          numSearches={props.courses.length + props.professors.length}
-          resultsPromise={props.searchResultsPromise}
-        />
-      </Suspense>
-    </>
+    <ClientLeft
+      numSearches={props.courses.length + props.professors.length}
+      resultsPromise={props.searchResultsPromise}
+    />
   );
 }

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,35 @@
+import Split from '@/components/common/Split/Split';
+import StickySide from '@/components/common/Split/StickySide';
+import Header from '@/components/navigation/Header/Header';
+import { LoadingFilters } from '@/components/search/Filters/Filters';
+import { LoadingSearchResultsTable } from '@/components/search/SearchResultsTable/SearchResultsTable';
+import React from 'react';
+import { LoadingRight } from './Right';
+
+export function DashboardLoadingContent() {
+  return (
+    <main className="p-4">
+      <LoadingFilters />
+      <Split
+        left={<LoadingSearchResultsTable />}
+        right={
+          <StickySide>
+            <LoadingRight />
+          </StickySide>
+        }
+        minLeft="40%"
+        minRight="30%"
+        defaultLeft="50%"
+      />
+    </main>
+  );
+}
+
+export default function Loading() {
+  return (
+    <>
+      <Header isPlanner={false} />
+      <DashboardLoadingContent />
+    </>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,8 +3,7 @@ import StickySide from '@/components/common/Split/StickySide';
 import ComparePage from '@/components/compare/ComparePage/ComparePage';
 import DashboardEmpty from '@/components/dashboard/DashboardEmpty/DashboardEmpty';
 import Header from '@/components/navigation/Header/Header';
-import Filters, { LoadingFilters } from '@/components/search/Filters/Filters';
-import { LoadingSearchResultsTable } from '@/components/search/SearchResultsTable/SearchResultsTable';
+import Filters from '@/components/search/Filters/Filters';
 import { createSearchQuery } from '@/modules/createSearchQuery';
 import { fetchSearchResults } from '@/modules/fetchSearchResult';
 import {
@@ -12,6 +11,7 @@ import {
   searchQueryLabel,
   searchQuerySort,
   type SearchQuery,
+  type SearchResult,
 } from '@/types/SearchQuery';
 import {
   dehydrate,
@@ -27,6 +27,62 @@ import ServerLeft from './ServerLeft';
 type Props = {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+async function DashboardContent({
+  searchResultsPromise,
+  queryClient,
+  courses,
+  professors,
+  isCompare,
+}: {
+  searchResultsPromise: Promise<SearchResult[]>;
+  queryClient: QueryClient;
+  courses: SearchQuery[];
+  professors: SearchQuery[];
+  isCompare: boolean;
+}) {
+  const searchResults = await searchResultsPromise;
+  return (
+    <FiltersProvider searchResults={searchResults}>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <main className="p-4">
+          <Filters searchResultsPromise={searchResultsPromise} />
+          {isCompare ? (
+            <ComparePage />
+          ) : (
+            <Split
+              left={
+                <ServerLeft
+                  searchResultsPromise={searchResultsPromise}
+                  courses={courses}
+                  professors={professors}
+                />
+              }
+              right={
+                <StickySide>
+                  <Suspense
+                    fallback={
+                      <LoadingRight courses={courses} professors={professors} />
+                    }
+                  >
+                    <Right
+                      courses={courses}
+                      professors={professors}
+                      searchResultsPromise={searchResultsPromise}
+                    />
+                  </Suspense>
+                </StickySide>
+              }
+              minLeft="40%"
+              minRight="30%"
+              defaultLeft="50%"
+            />
+          )}
+        </main>
+      </HydrationBoundary>
+    </FiltersProvider>
+  );
+}
 
 export async function generateMetadata({
   searchParams,
@@ -82,6 +138,9 @@ export async function generateMetadata({
  * Returns the results page
  */
 export default async function Page({ searchParams }: Props) {
+  if (process.env.NEXT_PUBLIC_DEBUG_LOADING === '1') {
+    await new Promise<void>((resolve) => setTimeout(resolve, 30_000));
+  }
   const resolvedParams = await searchParams;
   let searchTerms = resolvedParams.searchTerms;
   const isCompare = resolvedParams.compare === 'true';
@@ -119,81 +178,17 @@ export default async function Page({ searchParams }: Props) {
     results = createSearchQuery(professors, []);
   }
   const queryClient = new QueryClient();
-  const searchResults = fetchSearchResults(results);
+  const searchResultsPromise = fetchSearchResults(results);
   return (
     <>
-      <FiltersProvider searchResults={await searchResults}>
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <Header isPlanner={false} />
-          <main className="p-4">
-            <Suspense fallback={<LoadingFilters />}>
-              <Filters searchResultsPromise={searchResults} />
-            </Suspense>
-
-            {isCompare ? (
-              <ComparePage />
-            ) : (
-              <>
-                {/* Desktop Layout */}
-                <div className="hidden md:block">
-                  <Split
-                    left={
-                      <Suspense fallback={<LoadingSearchResultsTable />}>
-                        <ServerLeft
-                          searchResultsPromise={searchResults}
-                          courses={courses}
-                          professors={professors}
-                        />
-                      </Suspense>
-                    }
-                    right={
-                      <StickySide>
-                        <Suspense
-                          fallback={
-                            <LoadingRight
-                              courses={courses}
-                              professors={professors}
-                            />
-                          }
-                        >
-                          <Right
-                            courses={courses}
-                            professors={professors}
-                            searchResultsPromise={searchResults}
-                          />
-                        </Suspense>
-                      </StickySide>
-                    }
-                    minLeft="40%"
-                    minRight="30%"
-                    defaultLeft="50%"
-                  />
-                </div>
-
-                {/* Mobile Layout */}
-                <div className="block md:hidden mt-4">
-                  <Suspense
-                    fallback={
-                      <LoadingRight
-                        courses={courses}
-                        professors={professors}
-                        isMobile={true}
-                      />
-                    }
-                  >
-                    <Right
-                      courses={courses}
-                      professors={professors}
-                      searchResultsPromise={searchResults}
-                      isMobile={true}
-                    />
-                  </Suspense>
-                </div>
-              </>
-            )}
-          </main>
-        </HydrationBoundary>
-      </FiltersProvider>
+      <Header isPlanner={false} />
+      <DashboardContent
+        searchResultsPromise={searchResultsPromise}
+        queryClient={queryClient}
+        courses={courses}
+        professors={professors}
+        isCompare={isCompare}
+      />
     </>
   );
 }

--- a/src/app/planner/loading.tsx
+++ b/src/app/planner/loading.tsx
@@ -1,0 +1,14 @@
+import Header from '@/components/navigation/Header/Header';
+import React from 'react';
+import { PlannerLoadingSkeleton } from './Planner';
+
+export default function Loading() {
+  return (
+    <>
+      <Header isPlanner={true} />
+      <main className="p-4">
+        <PlannerLoadingSkeleton />
+      </main>
+    </>
+  );
+}

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -14,7 +14,10 @@ export const metadata: Metadata = {
 /**
  * Returns the My Planner page
  */
-export default function Page() {
+export default async function Page() {
+  if (process.env.NEXT_PUBLIC_DEBUG_LOADING === '1') {
+    await new Promise<void>((resolve) => setTimeout(resolve, 30_000));
+  }
   return (
     <>
       <PlannerPage />

--- a/src/components/search/Filters/Filters.tsx
+++ b/src/components/search/Filters/Filters.tsx
@@ -16,13 +16,12 @@ import type { SearchResult } from '@/types/SearchQuery';
 import {
   Checkbox,
   FormControl,
-  FormControlLabel,
   Grid,
   InputLabel,
   ListItemText,
   MenuItem,
   Select,
-  Switch,
+  Skeleton,
   Tooltip,
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
@@ -37,56 +36,36 @@ export function LoadingFilters() {
     <Grid container spacing={2} className="mb-4 sm:m-0">
       {/* min letter grade dropdown*/}
       <Grid size={{ xs: 6, sm: 9 / 5 }} className="px-2">
-        <FormControl
-          size="small"
-          className="w-full [&>.MuiInputBase-root]:bg-white dark:[&>.MuiInputBase-root]:bg-black"
-        >
-          <InputLabel id="minGPA">Min Letter Grade</InputLabel>
-          <Select label="Min Letter Grade" labelId="minGPA" value=""></Select>
-        </FormControl>
+        <Skeleton variant="rounded" className="h-10 w-full" />
       </Grid>
 
       {/* min rating dropdown*/}
       <Grid size={{ xs: 6, sm: 9 / 5 }} className="px-2">
-        <FormControl
-          size="small"
-          className="w-full [&>.MuiInputBase-root]:bg-white dark:[&>.MuiInputBase-root]:bg-black"
-        >
-          <InputLabel id="minRating">Min Rating</InputLabel>
-          <Select label="Min Rating" labelId="minRating" value=""></Select>
-        </FormControl>
+        <Skeleton variant="rounded" className="h-10 w-full" />
       </Grid>
 
       {/* semester dropdown */}
       <Grid size={{ xs: 6, sm: 9 / 5 }} className="px-2">
-        <FormControl
-          size="small"
-          className="w-full [&>.MuiInputBase-root]:bg-white dark:[&>.MuiInputBase-root]:bg-black"
-        >
-          <InputLabel id="Semesters">Semesters</InputLabel>
-          <Select label="Semesters" labelId="Semesters" value=""></Select>
-        </FormControl>
+        <Skeleton variant="rounded" className="h-10 w-full" />
       </Grid>
 
       {/* section type dropdown */}
       <Grid size={{ xs: 6, sm: 9 / 5 }} className="px-2">
-        <FormControl
-          size="small"
-          className="w-full [&>.MuiInputBase-root]:bg-white dark:[&>.MuiInputBase-root]:bg-black"
-        >
-          <InputLabel id="SectionTypes">Section Types</InputLabel>
-          <Select label="SectionTypes" labelId="SectionTypes" value=""></Select>
-        </FormControl>
+        <Skeleton variant="rounded" className="h-10 w-full" />
       </Grid>
 
-      {/* Teaching Next Semester switch*/}
+      {/* Teaching in + semester (matches TeachingSemesterSelector) */}
       <Grid size={{ xs: 12, sm: 24 / 5 }} className="px-2">
-        <FormControl size="small">
-          <FormControlLabel
-            control={<Switch checked={true} />}
-            label="Teaching Next Semester"
+        <div className="flex w-full flex-wrap items-center gap-2">
+          <Skeleton
+            variant="rounded"
+            className="h-[38px] min-w-[140px] flex-1 sm:flex-none"
           />
-        </FormControl>
+          <Skeleton
+            variant="rounded"
+            className="h-10 min-w-[120px] flex-1 sm:w-[120px]"
+          />
+        </div>
       </Grid>
     </Grid>
   );
@@ -566,7 +545,7 @@ export default function Filters({
         </Tooltip>
       </Grid>
 
-      {/* Teaching Next Semester switch + semester dropdown */}
+      {/* Teaching in semester selector */}
       <Grid size={{ xs: 12, sm: 24 / 5 }} className="px-2">
         <TeachingSemesterSelector
           enabled={filterNextSem}


### PR DESCRIPTION
Resolves #605 

Replace various loading UI with MUI Skeletons (home & filters), add dedicated loading pages/components for dashboard and planner, and improve loading UX. Refactor dashboard/page to extract DashboardContent, create DashboardLoadingContent add LoadingCompare component, and simplify Right/ServerLeft suspense handling. Fix FiltersProvider state updates by using useEffect to derive semesters/section types from search results. 

