### PR TITLE
fix(ui): sync Planner button visibility breakpoint with bottom bar

### DIFF
--- a/src/app/(home)/Home.tsx
+++ b/src/app/(home)/Home.tsx
@@ -67,7 +67,7 @@ export default function Home() {
             <b>Spring 2026</b> courses are now on Trends!
           </span>
         </a>*/}
-        <PlannerButton className="ml-auto" />
+        <PlannerButton className="ml-auto max-md:hidden" />
       </div>
       <div className="max-w-xl grow flex flex-col justify-center">
         <h2 className="text-sm font-semibold mb-3 text-royal dark:text-cornflower-300 tracking-wider flex gap-1 items-center">

--- a/src/components/navigation/Header/HeaderChildren.tsx
+++ b/src/components/navigation/Header/HeaderChildren.tsx
@@ -1,17 +1,8 @@
 'use client';
 
 import { useSharedState } from '@/app/SharedStateProvider';
-import {
-  WhatsNewBadge,
-  WhatsNewButton,
-  WhatsNewModal,
-  WhatsNewProvider,
-} from '@/components/common/WhatsNew/WhatsNew';
-import Tutorial, {
-  TutorialButton,
-  TutorialContext,
-  TutorialProvider,
-} from '@/components/dashboard/Tutorial/Tutorial';
+import { WhatsNewBadge, WhatsNewButton, WhatsNewModal, WhatsNewProvider } from '@/components/common/WhatsNew/WhatsNew';
+import Tutorial, { TutorialButton, TutorialContext, TutorialProvider } from '@/components/dashboard/Tutorial/Tutorial';
 import PlannerButton from '@/components/planner/PlannerButton/PlannerButton';
 import { setAvailabilitySemester } from '@/modules/availability';
 import DownloadIcon from '@mui/icons-material/Download';
@@ -28,6 +19,7 @@ import Tooltip from '@mui/material/Tooltip';
 import html2canvas from 'html2canvas-pro';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { type HeaderProps } from './Header';
+
 
 export default function HeaderChildren(props: HeaderProps) {
   return (
@@ -222,7 +214,7 @@ function HeaderChildrenInner(props: HeaderProps) {
       {/* Shown on large screens */}
       <div className="flex items-center gap-x-4 max-sm:hidden">
         {/* Planner button */}
-        <PlannerButton {...plannerButtonProps} />
+        <PlannerButton className="max-md:hidden" {...plannerButtonProps} />
 
         {/* Whats new button */}
         <div className="ml-auto">


### PR DESCRIPTION
## Overview

Fixes #624

Aligns the "My Planner" button breakpoint with the mobile bottom navigation bar so they no longer appear simultaneously at medium screen widths.

## What Changed

Planner button component: Updated visibility breakpoint from previous value to 768px to match the bottom bar

Result: Button shows only at widths > 768px, bottom bar shows only at widths ≤ 768px.
