### PR TITLE
Separate RMP and syllabus summaries

### DIFF
--- a/src/app/dashboard/Right.tsx
+++ b/src/app/dashboard/Right.tsx
@@ -13,7 +13,6 @@ import fetchGrades from '@/modules/fetchGrades';
 import fetchProfessor from '@/modules/fetchProfessor';
 import fetchRmp from '@/modules/fetchRmp';
 import { type SearchQuery, type SearchResult } from '@/types/SearchQuery';
-import { Card } from '@mui/material';
 import React, { Suspense } from 'react';
 import ServerLeft from './ServerLeft';
 

--- a/src/app/dashboard/Right.tsx
+++ b/src/app/dashboard/Right.tsx
@@ -1,3 +1,4 @@
+import BaseCard from '@/components/common/BaseCard/BaseCard';
 import Compare from '@/components/compare/Compare/Compare';
 import Carousel from '@/components/navigation/Carousel/Carousel';
 import CourseOverview, {
@@ -54,13 +55,13 @@ export function LoadingRight(props: LoadingRightProps) {
   }
 
   return (
-    <Card
+    <BaseCard
       className={`${props.isMobile ? 'bg-transparent bg-none shadow-none overflow-visible' : ''}`}
     >
       <Carousel key={names.join()} names={names} isMobile={props.isMobile}>
         {tabs}
       </Carousel>
-    </Card>
+    </BaseCard>
   );
 }
 
@@ -118,7 +119,7 @@ export default async function Right(props: Props) {
     const [profData, grades, rmp] = professorResults;
     names.push('Professor');
     tabs.push(
-      <Card
+      <BaseCard
         key="professor"
         className={`${props.isMobile ? 'p-6' : 'bg-transparent bg-none shadow-none'}`}
       >
@@ -128,7 +129,7 @@ export default async function Right(props: Props) {
           grades={grades}
           rmp={rmp}
         />
-      </Card>,
+      </BaseCard>,
     );
   }
 
@@ -136,7 +137,7 @@ export default async function Right(props: Props) {
     const [courseData, grades] = courseResults;
     names.push('Class');
     tabs.push(
-      <Card
+      <BaseCard
         key="course"
         className={`${props.isMobile ? 'p-6' : 'bg-transparent bg-none shadow-none'}`}
       >
@@ -145,7 +146,7 @@ export default async function Right(props: Props) {
           courseData={courseData}
           grades={grades}
         />
-      </Card>,
+      </BaseCard>,
     );
   }
 
@@ -155,12 +156,12 @@ export default async function Right(props: Props) {
   }
 
   return (
-    <Card
+    <BaseCard
       className={`${props.isMobile ? 'bg-transparent bg-none shadow-none overflow-visible' : ''}`}
     >
       <Carousel key={names.join()} names={names} isMobile={props.isMobile}>
         {tabs}
       </Carousel>
-    </Card>
+    </BaseCard>
   );
 }

--- a/src/components/common/BaseCard/BaseCard.tsx
+++ b/src/components/common/BaseCard/BaseCard.tsx
@@ -1,0 +1,37 @@
+type CardVariant = 'flat' | 'interactive' | 'transparent';
+
+type BaseCardProps = {
+  children: React.ReactNode;
+  variant?: CardVariant;
+  className?: string;
+  style?: React.CSSProperties;
+  id?: string;
+};
+
+const baseClasses = 'rounded-lg';
+
+const variantClasses: Record<CardVariant, string> = {
+  flat: 'shadow-sm dark:shadow-md',
+  interactive:
+    'shadow-lg dark:shadow-lg transition-all hover:shadow-xl dark:hover:shadow-2xl',
+  transparent: '',
+};
+
+export default function BaseCard({
+  children,
+  variant = 'flat',
+  className = '',
+  style,
+  id,
+}: BaseCardProps) {
+  const hasBgClass = className.includes('bg-');
+  return (
+    <div
+      {...(id ? { id } : {})}
+      style={style}
+      className={`${baseClasses} ${hasBgClass || variant === 'transparent' ? '' : 'bg-white dark:bg-neutral-800'} ${variantClasses[variant]} ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/RmpSummary/RmpSummary.tsx
+++ b/src/components/common/RmpSummary/RmpSummary.tsx
@@ -5,14 +5,13 @@ import { Skeleton, Tooltip, Typography } from '@mui/material';
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
-type LoadingProps = {
+type LoadingRmpSummaryProps = {
   legacyId?: string;
 };
 
-export function LoadingRmpSummary({ legacyId }: LoadingProps) {
+export function LoadingRmpSummary({ legacyId }: LoadingRmpSummaryProps) {
   return (
     <>
-      <Skeleton variant="text" />
       <Skeleton variant="text" />
       <Skeleton variant="text" />
       <Skeleton variant="text" className="w-1/2" />

--- a/src/components/common/RmpSummary/RmpSummary.tsx
+++ b/src/components/common/RmpSummary/RmpSummary.tsx
@@ -2,21 +2,39 @@
 
 import { type SearchQuery } from '@/types/SearchQuery';
 import { Skeleton, Tooltip, Typography } from '@mui/material';
+import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
-export function LoadingRmpSummary() {
+type LoadingProps = {
+  legacyId?: string;
+};
+
+export function LoadingRmpSummary({ legacyId }: LoadingProps) {
   return (
     <>
       <Skeleton variant="text" />
       <Skeleton variant="text" />
       <Skeleton variant="text" />
       <Skeleton variant="text" className="w-1/2" />
-      <Typography
-        variant="overline"
-        className="text-gray-700 dark:text-gray-300"
-      >
-        AI REVIEW SUMMARY
-      </Typography>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Typography
+          variant="overline"
+          className="text-gray-700 dark:text-gray-300"
+        >
+          AI REVIEW SUMMARY
+        </Typography>
+        {legacyId ? (
+          <Link
+            href={'https://www.ratemyprofessors.com/professor/' + legacyId}
+            target="_blank"
+            className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+          >
+            Visit Rate My Professors
+          </Link>
+        ) : (
+          <p>Visit Rate My Professors</p>
+        )}
+      </div>
     </>
   );
 }
@@ -24,9 +42,10 @@ export function LoadingRmpSummary() {
 type Props = {
   open: boolean;
   searchQuery: SearchQuery;
+  legacyId: string;
 };
 
-export default function RmpSummary({ open, searchQuery }: Props) {
+export default function RmpSummary({ open, searchQuery, legacyId }: Props) {
   const [summary, setSummary] = useState<string | null>(null);
   const [error, setError] = useState(false);
 
@@ -72,27 +91,47 @@ export default function RmpSummary({ open, searchQuery }: Props) {
   }, [open, searchQuery]);
 
   if (status === 'error') {
-    return <p>Problem loading AI review summary.</p>;
+    return (
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p>Problem loading AI review summary.</p>
+        <Link
+          href={'https://www.ratemyprofessors.com/professor/' + legacyId}
+          target="_blank"
+          className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+        >
+          Visit Rate My Professors
+        </Link>
+      </div>
+    );
   }
 
   if (!summary) {
-    return <LoadingRmpSummary />;
+    return <LoadingRmpSummary legacyId={legacyId} />;
   }
 
   return (
     <>
       <p>{summary}</p>
-      <Tooltip
-        title="This summary is AI generated. Please double check any important information"
-        placement="right"
-      >
-        <Typography
-          variant="overline"
-          className="text-gray-700 dark:text-gray-300"
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Tooltip
+          title="This summary is AI generated. Please double check any important information"
+          placement="right"
         >
-          AI REVIEW SUMMARY
-        </Typography>
-      </Tooltip>
+          <Typography
+            variant="overline"
+            className="text-gray-700 dark:text-gray-300"
+          >
+            AI REVIEW SUMMARY
+          </Typography>
+        </Tooltip>
+        <Link
+          href={'https://www.ratemyprofessors.com/professor/' + legacyId}
+          target="_blank"
+          className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+        >
+          Visit Rate My Professors
+        </Link>
+      </div>
     </>
   );
 }

--- a/src/components/common/SingleProfInfo/SingleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/SingleProfInfo.tsx
@@ -7,13 +7,7 @@ import SyllabusSummary from '@/components/common/SyllabusSummary/SyllabusSummary
 import type { RMP } from '@/modules/fetchRmp';
 import { isComboQuery, type SearchQuery } from '@/types/SearchQuery';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import {
-  Chip,
-  Collapse,
-  Grid,
-  IconButton,
-  Skeleton,
-} from '@mui/material';
+import { Chip, Collapse, Grid, IconButton, Skeleton } from '@mui/material';
 import Link from 'next/link';
 import React, { useState } from 'react';
 

--- a/src/components/common/SingleProfInfo/SingleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/SingleProfInfo.tsx
@@ -7,7 +7,14 @@ import SyllabusSummary from '@/components/common/SyllabusSummary/SyllabusSummary
 import type { RMP } from '@/modules/fetchRmp';
 import { isComboQuery, type SearchQuery } from '@/types/SearchQuery';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Chip, Collapse, Grid, IconButton, Skeleton } from '@mui/material';
+import {
+  Chip,
+  Collapse,
+  Divider,
+  Grid,
+  IconButton,
+  Skeleton,
+} from '@mui/material';
 import Link from 'next/link';
 import React, { useState } from 'react';
 
@@ -191,32 +198,6 @@ function Rmp({ open, searchQuery, rmp }: RmpProps) {
   );
 }
 
-type SyllabusProps = {
-  open: boolean;
-  searchQuery: SearchQuery;
-  syllabus_uri?: string | null;
-  syllabus_sem?: string | null;
-};
-
-function Syllabus({
-  open,
-  searchQuery,
-  syllabus_uri,
-  syllabus_sem,
-}: SyllabusProps) {
-  if (!syllabus_uri || !syllabus_sem || !isComboQuery(searchQuery)) {
-    return null;
-  }
-  return (
-    <SyllabusSummary
-      open={open}
-      searchQuery={searchQuery}
-      syllabus_uri={syllabus_uri}
-      syllabus_sem={syllabus_sem}
-    />
-  );
-}
-
 type Props = {
   open: boolean;
   searchQuery: SearchQuery;
@@ -233,14 +214,24 @@ export default function SingleProfInfo({
   syllabus_sem,
 }: Props) {
   return (
-    <Grid container spacing={2} className="p-4">
-      <Rmp open={open} searchQuery={searchQuery} rmp={rmp} />
-      <Syllabus
-        open={open}
-        searchQuery={searchQuery}
-        syllabus_uri={syllabus_uri}
-        syllabus_sem={syllabus_sem}
-      />
-    </Grid>
+    <>
+      <Divider />
+      <Grid container spacing={2} className="p-4">
+        <Rmp open={open} searchQuery={searchQuery} rmp={rmp} />
+      </Grid>
+      {syllabus_uri && syllabus_sem && isComboQuery(searchQuery) && (
+        <>
+          <Divider />
+          <Grid container spacing={2} className="p-4">
+            <SyllabusSummary
+              open={open}
+              searchQuery={searchQuery}
+              syllabus_uri={syllabus_uri}
+              syllabus_sem={syllabus_sem}
+            />
+          </Grid>
+        </>
+      )}
+    </>
   );
 }

--- a/src/components/common/SingleProfInfo/SingleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/SingleProfInfo.tsx
@@ -5,8 +5,7 @@ import RmpSummary, {
 } from '@/components/common/RmpSummary/RmpSummary';
 import SyllabusSummary from '@/components/common/SyllabusSummary/SyllabusSummary';
 import type { RMP } from '@/modules/fetchRmp';
-import type { SearchQuery } from '@/types/SearchQuery';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { isComboQuery, type SearchQuery } from '@/types/SearchQuery';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
   Button,
@@ -212,7 +211,7 @@ function Syllabus({
   syllabus_uri,
   syllabus_sem,
 }: SyllabusProps) {
-  if (!syllabus_uri || !syllabus_sem) {
+  if (!syllabus_uri || !syllabus_sem || !isComboQuery(searchQuery)) {
     return null;
   }
   return (

--- a/src/components/common/SingleProfInfo/SingleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/SingleProfInfo.tsx
@@ -8,7 +8,6 @@ import type { RMP } from '@/modules/fetchRmp';
 import { isComboQuery, type SearchQuery } from '@/types/SearchQuery';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
-  Button,
   Chip,
   Collapse,
   Grid,

--- a/src/components/common/SingleProfInfo/SingleProfInfo.tsx
+++ b/src/components/common/SingleProfInfo/SingleProfInfo.tsx
@@ -8,7 +8,14 @@ import type { RMP } from '@/modules/fetchRmp';
 import type { SearchQuery } from '@/types/SearchQuery';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Chip, Collapse, Grid, IconButton, Skeleton } from '@mui/material';
+import {
+  Button,
+  Chip,
+  Collapse,
+  Grid,
+  IconButton,
+  Skeleton,
+} from '@mui/material';
 import Link from 'next/link';
 import React, { useState } from 'react';
 
@@ -76,27 +83,18 @@ export function LoadingSingleProfInfo() {
   );
 }
 
-type Props = {
+type RmpProps = {
   open: boolean;
   searchQuery: SearchQuery;
   rmp: RMP;
-  syllabus_uri?: string | null;
-  syllabus_sem?: string | null;
 };
 
-export default function SingleProfInfo({
-  open,
-  searchQuery,
-  rmp,
-  syllabus_uri,
-  syllabus_sem,
-}: Props) {
-  const [showMore, setShowMore] = useState(false);
-  const [showSyllabus, setShowSyllabus] = useState(false);
+function Rmp({ open, searchQuery, rmp }: RmpProps) {
+  const [showMoreTags, setShowMoreTags] = useState(false);
 
   if (rmp.numRatings == 0) {
     return (
-      <Grid container spacing={2} className="p-4">
+      <>
         <Grid size={6}>
           <p className="text-xl font-bold">{rmp.numRatings.toLocaleString()}</p>
           <p>Ratings given</p>
@@ -110,7 +108,7 @@ export default function SingleProfInfo({
             Visit Rate My Professors
           </Link>
         </Grid>
-      </Grid>
+      </>
     );
   }
 
@@ -119,7 +117,7 @@ export default function SingleProfInfo({
   const next5 = topTags.slice(5, 10);
 
   return (
-    <Grid container spacing={2} className="p-4">
+    <>
       <Grid size={6}>
         <p className="text-xl font-bold">
           {rmp.avgRating > 0 ? rmp.avgRating : 'N/A'}
@@ -159,7 +157,11 @@ export default function SingleProfInfo({
             {next5.length > 0 && (
               <>
                 {next5.map((tag, index) => (
-                  <Collapse key={index} in={showMore} orientation="horizontal">
+                  <Collapse
+                    key={index}
+                    in={showMoreTags}
+                    orientation="horizontal"
+                  >
                     <Chip
                       label={`${tag.tagName} (${tag.tagCount})`}
                       variant="outlined"
@@ -170,11 +172,12 @@ export default function SingleProfInfo({
                 <IconButton
                   size="small"
                   aria-label="show more"
-                  onClick={() => setShowMore(!showMore)}
+                  onClick={() => setShowMoreTags(!showMoreTags)}
                 >
                   <ExpandMoreIcon
                     className={
-                      'transition ' + (showMore ? 'rotate-90' : '-rotate-90')
+                      'transition ' +
+                      (showMoreTags ? 'rotate-90' : '-rotate-90')
                     }
                   />
                 </IconButton>
@@ -189,38 +192,63 @@ export default function SingleProfInfo({
           key={JSON.stringify(searchQuery)}
           open={open}
           searchQuery={searchQuery}
+          legacyId={rmp.legacyId}
         />
       </Grid>
+    </>
+  );
+}
 
-      <Grid size={12}>
-        <div className="flex gap-7">
-          <Link
-            href={'https://www.ratemyprofessors.com/professor/' + rmp.legacyId}
-            target="_blank"
-            className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
-          >
-            Visit Rate My Professors
-          </Link>
+type SyllabusProps = {
+  open: boolean;
+  searchQuery: SearchQuery;
+  syllabus_uri?: string | null;
+  syllabus_sem?: string | null;
+};
 
-          {syllabus_uri && (
-            <button onClick={() => setShowSyllabus(!showSyllabus)}>
-              View Syllabus Summary
-              {syllabus_sem ? ` for ${syllabus_sem}` : ''}{' '}
-              <ChevronRightIcon
-                className={`transition-transform ${showSyllabus ? 'rotate-90' : ''}`}
-              />
-            </button>
-          )}
-        </div>
-        {syllabus_uri && (
-          <SyllabusSummary
-            open={open}
-            searchQuery={searchQuery}
-            showSyllabus={showSyllabus}
-            syllabus_uri={syllabus_uri}
-          />
-        )}
-      </Grid>
+function Syllabus({
+  open,
+  searchQuery,
+  syllabus_uri,
+  syllabus_sem,
+}: SyllabusProps) {
+  if (!syllabus_uri || !syllabus_sem) {
+    return null;
+  }
+  return (
+    <SyllabusSummary
+      open={open}
+      searchQuery={searchQuery}
+      syllabus_uri={syllabus_uri}
+      syllabus_sem={syllabus_sem}
+    />
+  );
+}
+
+type Props = {
+  open: boolean;
+  searchQuery: SearchQuery;
+  rmp: RMP;
+  syllabus_uri?: string | null;
+  syllabus_sem?: string | null;
+};
+
+export default function SingleProfInfo({
+  open,
+  searchQuery,
+  rmp,
+  syllabus_uri,
+  syllabus_sem,
+}: Props) {
+  return (
+    <Grid container spacing={2} className="p-4">
+      <Rmp open={open} searchQuery={searchQuery} rmp={rmp} />
+      <Syllabus
+        open={open}
+        searchQuery={searchQuery}
+        syllabus_uri={syllabus_uri}
+        syllabus_sem={syllabus_sem}
+      />
     </Grid>
   );
 }

--- a/src/components/common/SyllabusSummary/SyllabusSummary.tsx
+++ b/src/components/common/SyllabusSummary/SyllabusSummary.tsx
@@ -1,7 +1,20 @@
 'use client';
 
+import BaseCard from '@/components/common/BaseCard/BaseCard';
 import { type SearchQuery } from '@/types/SearchQuery';
-import { Collapse, Link, Skeleton, Typography } from '@mui/material';
+import {
+  Grid,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
 export function LoadingSyllabusSummary() {
@@ -33,20 +46,20 @@ type Props = {
   open: boolean;
   searchQuery: SearchQuery;
   syllabus_uri: string;
-  showSyllabus: boolean;
+  syllabus_sem: string;
 };
 
 export default function SyllabusSummary({
   open,
   searchQuery,
   syllabus_uri,
-  showSyllabus,
+  syllabus_sem,
 }: Props) {
   const [state, setState] = useState<'closed' | 'error' | 'done'>('closed');
   const [syllabus, setSyllabus] = useState<SyllabusData | null>(null);
 
   useEffect(() => {
-    if (open && showSyllabus && !syllabus && state !== 'error') {
+    if (open && !syllabus && state !== 'error') {
       const params = new URLSearchParams();
       if (syllabus_uri) params.append('syllabus_uri', syllabus_uri);
       fetch(`/api/syllabusSummary?${params.toString()}`, {
@@ -63,97 +76,129 @@ export default function SyllabusSummary({
           setSyllabus(data.data);
         });
     }
-  }, [open, state, searchQuery, syllabus_uri, showSyllabus, syllabus]);
+  }, [open, state, searchQuery, syllabus_uri, syllabus]);
 
   if (state === 'error') {
-    return <p>Problem loading AI syllabus summary.</p>;
+    return (
+      <Grid size={12}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p>Problem loading AI syllabus summary.</p>
+          <Link
+            href={syllabus_uri}
+            target="_blank"
+            className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+          >
+            View Syllabus
+          </Link>
+        </div>
+      </Grid>
+    );
   }
 
   return (
     <>
-      <Collapse in={showSyllabus}>
-        {!syllabus ? (
-          <LoadingSyllabusSummary />
-        ) : (
-          <div className="mt-2 rounded pv-3 max-w-dvw">
-            {/* Outer flex row: tables + AI summary */}
-            <div className="flex gap-8 items-start mt-2 flex-wrap rounded p-4 dark:bg-neutral-900/50 bg-neutral-200 border border-cornflower-500">
-              {/* Tables wrapper */}
-              <div className="tables-container flex items-start gap-8 width-full max-w-dvw">
-                {/* Weighting Table */}
-                {syllabus.grade_weights != null &&
-                  syllabus.grade_weights.length > 0 && (
-                    <table className="text-sm">
-                      <thead>
-                        <tr>
-                          <th className="px-2 py-1 font-bold text-md">
-                            Weighting
-                          </th>
-                          <th className="px-2 py-1 font-bold text-md">%</th>
-                        </tr>
-                      </thead>
-                      <tbody>
+      {!syllabus ? (
+        <LoadingSyllabusSummary />
+      ) : (
+        <>
+          {/* Weighting Table */}
+          {syllabus.grade_weights != null &&
+            syllabus.grade_weights.length > 0 && (
+              <Grid size={6}>
+                <BaseCard className="dark:bg-neutral-700">
+                  <TableContainer>
+                    <Table size="small" aria-label="grade weighting table">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell className="font-bold">Weighting</TableCell>
+                          <TableCell className="font-bold">%</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
                         {syllabus.grade_weights.map((row, idx) => (
-                          <tr key={idx}>
-                            <td className="px-2 py-1">{row.category}</td>
-                            <td className="px-2 py-1">{row.percentage}</td>
-                          </tr>
+                          <TableRow
+                            key={idx}
+                            sx={{
+                              '&:last-child td, &:last-child th': { border: 0 },
+                            }}
+                          >
+                            <TableCell component="th" scope="row">
+                              {row.category}
+                            </TableCell>
+                            <TableCell>{row.percentage}</TableCell>
+                          </TableRow>
                         ))}
-                      </tbody>
-                    </table>
-                  )}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                </BaseCard>
+              </Grid>
+            )}
 
-                {/* Grade Scale Table */}
-                {syllabus.letter_grade_scale != null &&
-                  syllabus.letter_grade_scale.length > 0 && (
-                    <table className="text-sm">
-                      <thead>
-                        <tr>
-                          <th className="px-2 py-1 font-bold text-md">Grade</th>
-                          <th className="px-2 py-1 font-bold text-md">Scale</th>
-                        </tr>
-                      </thead>
-                      <tbody>
+          {/* Grade Scale Table */}
+          {syllabus.letter_grade_scale != null &&
+            syllabus.letter_grade_scale.length > 0 && (
+              <Grid size={6}>
+                <BaseCard className="dark:bg-neutral-700">
+                  <TableContainer>
+                    <Table size="small" aria-label="grade scale table">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell className="font-bold">Grade</TableCell>
+                          <TableCell className="font-bold">Scale</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
                         {syllabus.letter_grade_scale.map((row, idx) => (
-                          <tr key={idx}>
-                            <td className="px-2 py-1">{row.grade}</td>
-                            <td className="px-2 py-1">{row.range}</td>
-                          </tr>
+                          <TableRow
+                            key={idx}
+                            sx={{
+                              '&:last-child td, &:last-child th': { border: 0 },
+                            }}
+                          >
+                            <TableCell component="th" scope="row">
+                              {row.grade}
+                            </TableCell>
+                            <TableCell>{row.range}</TableCell>
+                          </TableRow>
                         ))}
-                      </tbody>
-                    </table>
-                  )}
-              </div>
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                </BaseCard>
+              </Grid>
+            )}
 
-              {/* AI Summary / Placeholder */}
-              <div
-                id="ai-summary"
-                className="text-sm flex flex-col items-start flex-1 min-h-[100px] max-w-dvw"
+          {/* AI Summary / Placeholder */}
+          <Grid size={12}>
+            {syllabus.summary != null ? (
+              <p>{syllabus.summary}</p>
+            ) : (
+              <p>Could not summarize the syllabus.</p>
+            )}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <Tooltip
+                title="This summary is AI generated. Please double check any important information"
+                placement="right"
               >
-                <p className="py-1 font-bold text-md">Course Notes</p>
-                {syllabus.summary != null ? (
-                  <p>{syllabus.summary}</p>
-                ) : (
-                  <p>Could not summarize the syllabus</p>
-                )}
-                <Link
-                  href={syllabus_uri}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <Typography
+                  variant="overline"
+                  className="text-gray-700 dark:text-gray-300"
                 >
-                  View Syllabus
-                </Link>
-              </div>
+                  AI SYLLABUS SUMMARY
+                </Typography>
+              </Tooltip>
+              <Link
+                href={syllabus_uri}
+                target="_blank"
+                className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+              >
+                View Syllabus
+              </Link>
             </div>
-            <Typography
-              variant="overline"
-              className="text-gray-700 dark:text-gray-300"
-            >
-              AI GENERATED SYLLABUS SUMMARY
-            </Typography>
-          </div>
-        )}
-      </Collapse>
+          </Grid>
+        </>
+      )}
     </>
   );
 }

--- a/src/components/common/SyllabusSummary/SyllabusSummary.tsx
+++ b/src/components/common/SyllabusSummary/SyllabusSummary.tsx
@@ -21,22 +21,151 @@ import React, { useEffect, useState } from 'react';
 
 const MAX_VISIBLE_ROWS = 2;
 
-export function LoadingSyllabusSummary() {
+type LoadingSyllabusSummaryProps = {
+  syllabus_uri?: string;
+  syllabus_sem?: string;
+};
+
+export function LoadingSyllabusSummary({
+  syllabus_uri,
+  syllabus_sem,
+}: LoadingSyllabusSummaryProps) {
   return (
-    <div className="mt-2 rounded pv-3 max-w-dvw">
-      <div className="rounded p-4 dark:bg-neutral-900/50 bg-neutral-200 border border-cornflower-500">
-        <Skeleton variant="text" />
+    <>
+      {/* Weighting Table */}
+      <Grid size={6}>
+        <BaseCard className="dark:bg-neutral-700">
+          <TableContainer>
+            <Table size="small" aria-label="grade weighting table">
+              <colgroup>
+                <col className="w-1/2" />
+                <col className="w-1/2" />
+              </colgroup>
+              <TableHead>
+                <TableRow>
+                  <TableCell className="font-bold">Weighting</TableCell>
+                  <TableCell className="font-bold">%</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {Array(2)
+                  .fill(0)
+                  .map((_, idx) => (
+                    <TableRow
+                      key={idx}
+                      sx={{
+                        '&:last-child td, &:last-child th': {
+                          border: 0,
+                        },
+                      }}
+                    >
+                      <TableCell component="th" scope="row">
+                        <Skeleton variant="text" className="w-1/2" />
+                      </TableCell>
+                      <TableCell>
+                        <Skeleton variant="text" className="w-1/4" />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                <TableRow
+                  sx={{
+                    '&:last-child td, &:last-child th': {
+                      border: 0,
+                    },
+                  }}
+                >
+                  <TableCell align="center" className="py-0" colSpan={2}>
+                    <Button className="normal-case" size="small" disabled>
+                      Show More
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </BaseCard>
+      </Grid>
+
+      {/* Grade Scale Table */}
+      <Grid size={6}>
+        <BaseCard className="dark:bg-neutral-700">
+          <TableContainer>
+            <Table size="small" aria-label="grade scale table">
+              <colgroup>
+                <col className="w-1/2" />
+                <col className="w-1/2" />
+              </colgroup>
+              <TableHead>
+                <TableRow>
+                  <TableCell className="font-bold">Grade</TableCell>
+                  <TableCell className="font-bold">Scale</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {Array(2)
+                  .fill(0)
+                  .map((_, idx) => (
+                    <TableRow
+                      key={idx}
+                      sx={{
+                        '&:last-child td, &:last-child th': {
+                          border: 0,
+                        },
+                      }}
+                    >
+                      <TableCell component="th" scope="row">
+                        <Skeleton variant="text" className="w-1/4" />
+                      </TableCell>
+                      <TableCell>
+                        <Skeleton variant="text" className="w-1/4" />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                <TableRow
+                  sx={{
+                    '&:last-child td, &:last-child th': {
+                      border: 0,
+                    },
+                  }}
+                >
+                  <TableCell align="center" className="py-0" colSpan={2}>
+                    <Button className="normal-case" size="small" disabled>
+                      Show More
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </BaseCard>
+      </Grid>
+
+      {/* AI Summary / Placeholder */}
+      <Grid size={12}>
         <Skeleton variant="text" />
         <Skeleton variant="text" />
         <Skeleton variant="text" className="w-1/2" />
-      </div>
-      <Typography
-        variant="overline"
-        className="text-gray-700 dark:text-gray-300 pr-5"
-      >
-        AI GENERATED SYLLABUS SUMMARY
-      </Typography>
-    </div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <Typography
+            variant="overline"
+            className="text-gray-700 dark:text-gray-300"
+          >
+            AI SYLLABUS SUMMARY
+          </Typography>
+          {syllabus_uri && syllabus_sem ? (
+            <Link
+              href={syllabus_uri}
+              target="_blank"
+              className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+            >
+              View {syllabus_sem} Syllabus
+            </Link>
+          ) : (
+            <p>View Syllabus</p>
+          )}
+        </div>
+      </Grid>
+    </>
   );
 }
 
@@ -105,7 +234,10 @@ export default function SyllabusSummary({
   return (
     <>
       {!syllabus ? (
-        <LoadingSyllabusSummary />
+        <LoadingSyllabusSummary
+          syllabus_uri={syllabus_uri}
+          syllabus_sem={syllabus_sem}
+        />
       ) : (
         <>
           {/* Weighting Table */}

--- a/src/components/common/SyllabusSummary/SyllabusSummary.tsx
+++ b/src/components/common/SyllabusSummary/SyllabusSummary.tsx
@@ -34,7 +34,7 @@ export function LoadingSyllabusSummary({
     <>
       {/* Weighting Table */}
       <Grid size={6}>
-        <BaseCard className="dark:bg-neutral-700">
+        <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
           <TableContainer>
             <Table size="small" aria-label="grade weighting table">
               <colgroup>
@@ -88,7 +88,7 @@ export function LoadingSyllabusSummary({
 
       {/* Grade Scale Table */}
       <Grid size={6}>
-        <BaseCard className="dark:bg-neutral-700">
+        <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
           <TableContainer>
             <Table size="small" aria-label="grade scale table">
               <colgroup>
@@ -244,7 +244,7 @@ export default function SyllabusSummary({
           {syllabus.grade_weights != null &&
             syllabus.grade_weights.length > 0 && (
               <Grid size={6}>
-                <BaseCard className="dark:bg-neutral-700">
+                <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
                   <TableContainer>
                     <Table size="small" aria-label="grade weighting table">
                       <colgroup>
@@ -346,7 +346,7 @@ export default function SyllabusSummary({
           {syllabus.letter_grade_scale != null &&
             syllabus.letter_grade_scale.length > 0 && (
               <Grid size={6}>
-                <BaseCard className="dark:bg-neutral-700">
+                <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
                   <TableContainer>
                     <Table size="small" aria-label="grade scale table">
                       <colgroup>

--- a/src/components/common/SyllabusSummary/SyllabusSummary.tsx
+++ b/src/components/common/SyllabusSummary/SyllabusSummary.tsx
@@ -21,6 +21,154 @@ import React, { useEffect, useState } from 'react';
 
 const MAX_VISIBLE_ROWS = 2;
 
+interface LoadingGradeTableProps {
+  title: [string, string];
+  dataWidths: [string, string];
+}
+
+function LoadingGradeTable({ title, dataWidths }: LoadingGradeTableProps) {
+  return (
+    <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
+      <TableContainer>
+        <Table size="small" aria-label="grade weighting table">
+          <colgroup>
+            <col className="w-1/2" />
+            <col className="w-1/2" />
+          </colgroup>
+          <TableHead>
+            <TableRow>
+              <TableCell className="font-bold">{title[0]}</TableCell>
+              <TableCell className="font-bold">{title[1]}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {Array(2)
+              .fill(0)
+              .map((_, idx) => (
+                <TableRow
+                  key={idx}
+                  sx={{
+                    '&:last-child td, &:last-child th': {
+                      border: 0,
+                    },
+                  }}
+                >
+                  <TableCell component="th" scope="row">
+                    <Skeleton variant="text" className={dataWidths[0]} />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton variant="text" className={dataWidths[1]} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            <TableRow
+              sx={{
+                '&:last-child td, &:last-child th': {
+                  border: 0,
+                },
+              }}
+            >
+              <TableCell align="center" className="py-0" colSpan={2}>
+                <Button className="normal-case" size="small" disabled>
+                  Show More
+                </Button>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </BaseCard>
+  );
+}
+
+interface GradeTableProps {
+  title: [string, string];
+  data: [string, string][];
+}
+
+function GradeTable({ title, data }: GradeTableProps) {
+  const [showMore, setShowMore] = useState(false);
+
+  return (
+    <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
+      <TableContainer>
+        <Table size="small" aria-label="grade weighting table">
+          <colgroup>
+            <col className="w-1/2" />
+            <col className="w-1/2" />
+          </colgroup>
+          <TableHead>
+            <TableRow>
+              <TableCell className="font-bold">{title[0]}</TableCell>
+              <TableCell className="font-bold">{title[1]}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.slice(0, MAX_VISIBLE_ROWS).map((row, idx) => (
+              <TableRow
+                key={idx}
+                sx={{
+                  '&:last-child td, &:last-child th': {
+                    border: 0,
+                  },
+                }}
+              >
+                <TableCell component="th" scope="row">
+                  {row[0]}
+                </TableCell>
+                <TableCell>{row[1]}</TableCell>
+              </TableRow>
+            ))}
+            {data.length > MAX_VISIBLE_ROWS && (
+              <>
+                <TableRow>
+                  <TableCell colSpan={2} className="p-0 border-0">
+                    <Collapse in={showMore} timeout="auto" unmountOnExit>
+                      <Table size="small">
+                        <colgroup>
+                          <col className="w-1/2" />
+                          <col className="w-1/2" />
+                        </colgroup>
+                        <TableBody>
+                          {data.slice(MAX_VISIBLE_ROWS).map((row, idx) => (
+                            <TableRow key={idx}>
+                              <TableCell component="th" scope="row">
+                                {row[0]}
+                              </TableCell>
+                              <TableCell>{row[1]}</TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </Collapse>
+                  </TableCell>
+                </TableRow>
+                <TableRow
+                  sx={{
+                    '&:last-child td, &:last-child th': {
+                      border: 0,
+                    },
+                  }}
+                >
+                  <TableCell align="center" className="py-0" colSpan={2}>
+                    <Button
+                      className="normal-case"
+                      size="small"
+                      onClick={() => setShowMore(!showMore)}
+                    >
+                      {showMore ? 'Show Less' : 'Show More'}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              </>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </BaseCard>
+  );
+}
+
 type LoadingSyllabusSummaryProps = {
   syllabus_uri?: string;
   syllabus_sem?: string;
@@ -34,110 +182,18 @@ export function LoadingSyllabusSummary({
     <>
       {/* Weighting Table */}
       <Grid size={6}>
-        <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
-          <TableContainer>
-            <Table size="small" aria-label="grade weighting table">
-              <colgroup>
-                <col className="w-1/2" />
-                <col className="w-1/2" />
-              </colgroup>
-              <TableHead>
-                <TableRow>
-                  <TableCell className="font-bold">Weighting</TableCell>
-                  <TableCell className="font-bold">%</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {Array(2)
-                  .fill(0)
-                  .map((_, idx) => (
-                    <TableRow
-                      key={idx}
-                      sx={{
-                        '&:last-child td, &:last-child th': {
-                          border: 0,
-                        },
-                      }}
-                    >
-                      <TableCell component="th" scope="row">
-                        <Skeleton variant="text" className="w-1/2" />
-                      </TableCell>
-                      <TableCell>
-                        <Skeleton variant="text" className="w-1/4" />
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                <TableRow
-                  sx={{
-                    '&:last-child td, &:last-child th': {
-                      border: 0,
-                    },
-                  }}
-                >
-                  <TableCell align="center" className="py-0" colSpan={2}>
-                    <Button className="normal-case" size="small" disabled>
-                      Show More
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </BaseCard>
+        <LoadingGradeTable
+          title={['Weighting', '%']}
+          dataWidths={['w-1/2', 'w-1/4']}
+        />
       </Grid>
 
       {/* Grade Scale Table */}
       <Grid size={6}>
-        <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
-          <TableContainer>
-            <Table size="small" aria-label="grade scale table">
-              <colgroup>
-                <col className="w-1/2" />
-                <col className="w-1/2" />
-              </colgroup>
-              <TableHead>
-                <TableRow>
-                  <TableCell className="font-bold">Grade</TableCell>
-                  <TableCell className="font-bold">Scale</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {Array(2)
-                  .fill(0)
-                  .map((_, idx) => (
-                    <TableRow
-                      key={idx}
-                      sx={{
-                        '&:last-child td, &:last-child th': {
-                          border: 0,
-                        },
-                      }}
-                    >
-                      <TableCell component="th" scope="row">
-                        <Skeleton variant="text" className="w-1/4" />
-                      </TableCell>
-                      <TableCell>
-                        <Skeleton variant="text" className="w-1/4" />
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                <TableRow
-                  sx={{
-                    '&:last-child td, &:last-child th': {
-                      border: 0,
-                    },
-                  }}
-                >
-                  <TableCell align="center" className="py-0" colSpan={2}>
-                    <Button className="normal-case" size="small" disabled>
-                      Show More
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </BaseCard>
+        <LoadingGradeTable
+          title={['Grade', 'Scale']}
+          dataWidths={['w-1/4', 'w-1/4']}
+        />
       </Grid>
 
       {/* AI Summary / Placeholder */}
@@ -211,9 +267,6 @@ export default function SyllabusSummary({
     }
   }, [open, state, searchQuery, syllabus_uri, syllabus]);
 
-  const [showMoreWeights, setShowMoreWeights] = useState(false);
-  const [showMoreGrades, setShowMoreGrades] = useState(false);
-
   if (state === 'error') {
     return (
       <Grid size={12}>
@@ -244,101 +297,13 @@ export default function SyllabusSummary({
           {syllabus.grade_weights != null &&
             syllabus.grade_weights.length > 0 && (
               <Grid size={6}>
-                <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
-                  <TableContainer>
-                    <Table size="small" aria-label="grade weighting table">
-                      <colgroup>
-                        <col className="w-1/2" />
-                        <col className="w-1/2" />
-                      </colgroup>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell className="font-bold">Weighting</TableCell>
-                          <TableCell className="font-bold">%</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {syllabus.grade_weights
-                          .slice(0, MAX_VISIBLE_ROWS)
-                          .map((row, idx) => (
-                            <TableRow
-                              key={idx}
-                              sx={{
-                                '&:last-child td, &:last-child th': {
-                                  border: 0,
-                                },
-                              }}
-                            >
-                              <TableCell component="th" scope="row">
-                                {row.category}
-                              </TableCell>
-                              <TableCell>{row.percentage}</TableCell>
-                            </TableRow>
-                          ))}
-                        {syllabus.grade_weights.length > MAX_VISIBLE_ROWS && (
-                          <>
-                            <TableRow>
-                              <TableCell colSpan={2} className="p-0 border-0">
-                                <Collapse
-                                  in={showMoreWeights}
-                                  timeout="auto"
-                                  unmountOnExit
-                                >
-                                  <Table size="small">
-                                    <colgroup>
-                                      <col className="w-1/2" />
-                                      <col className="w-1/2" />
-                                    </colgroup>
-                                    <TableBody>
-                                      {syllabus.grade_weights
-                                        .slice(MAX_VISIBLE_ROWS)
-                                        .map((row, idx) => (
-                                          <TableRow key={idx}>
-                                            <TableCell
-                                              component="th"
-                                              scope="row"
-                                            >
-                                              {row.category}
-                                            </TableCell>
-                                            <TableCell>
-                                              {row.percentage}
-                                            </TableCell>
-                                          </TableRow>
-                                        ))}
-                                    </TableBody>
-                                  </Table>
-                                </Collapse>
-                              </TableCell>
-                            </TableRow>
-                            <TableRow
-                              sx={{
-                                '&:last-child td, &:last-child th': {
-                                  border: 0,
-                                },
-                              }}
-                            >
-                              <TableCell
-                                align="center"
-                                className="py-0"
-                                colSpan={2}
-                              >
-                                <Button
-                                  className="normal-case"
-                                  size="small"
-                                  onClick={() =>
-                                    setShowMoreWeights(!showMoreWeights)
-                                  }
-                                >
-                                  {showMoreWeights ? 'Show Less' : 'Show More'}
-                                </Button>
-                              </TableCell>
-                            </TableRow>
-                          </>
-                        )}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </BaseCard>
+                <GradeTable
+                  title={['Weighting', '%']}
+                  data={syllabus.grade_weights.map((row) => [
+                    row.category,
+                    row.percentage,
+                  ])}
+                />
               </Grid>
             )}
 
@@ -346,100 +311,13 @@ export default function SyllabusSummary({
           {syllabus.letter_grade_scale != null &&
             syllabus.letter_grade_scale.length > 0 && (
               <Grid size={6}>
-                <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
-                  <TableContainer>
-                    <Table size="small" aria-label="grade scale table">
-                      <colgroup>
-                        <col className="w-1/2" />
-                        <col className="w-1/2" />
-                      </colgroup>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell className="font-bold">Grade</TableCell>
-                          <TableCell className="font-bold">Scale</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {syllabus.letter_grade_scale
-                          .slice(0, MAX_VISIBLE_ROWS)
-                          .map((row, idx) => (
-                            <TableRow
-                              key={idx}
-                              sx={{
-                                '&:last-child td, &:last-child th': {
-                                  border: 0,
-                                },
-                              }}
-                            >
-                              <TableCell component="th" scope="row">
-                                {row.grade}
-                              </TableCell>
-                              <TableCell>{row.range}</TableCell>
-                            </TableRow>
-                          ))}
-                        {syllabus.letter_grade_scale.length >
-                          MAX_VISIBLE_ROWS && (
-                          <>
-                            <TableRow>
-                              <TableCell colSpan={2} className="p-0 border-0">
-                                <Collapse
-                                  in={showMoreGrades}
-                                  timeout="auto"
-                                  unmountOnExit
-                                >
-                                  <Table size="small">
-                                    <colgroup>
-                                      <col className="w-1/2" />
-                                      <col className="w-1/2" />
-                                    </colgroup>
-                                    <TableBody>
-                                      {syllabus.letter_grade_scale
-                                        .slice(MAX_VISIBLE_ROWS)
-                                        .map((row, idx) => (
-                                          <TableRow key={idx}>
-                                            <TableCell
-                                              component="th"
-                                              scope="row"
-                                            >
-                                              {row.grade}
-                                            </TableCell>
-                                            <TableCell>{row.range}</TableCell>
-                                          </TableRow>
-                                        ))}
-                                    </TableBody>
-                                  </Table>
-                                </Collapse>
-                              </TableCell>
-                            </TableRow>
-                            <TableRow
-                              sx={{
-                                '&:last-child td, &:last-child th': {
-                                  border: 0,
-                                },
-                              }}
-                            >
-                              <TableCell
-                                align="center"
-                                className="py-0"
-                                colSpan={2}
-                              >
-                                <Button
-                                  className="normal-case"
-                                  size="small"
-                                  onClick={() =>
-                                    setShowMoreGrades(!showMoreGrades)
-                                  }
-                                >
-                                  {showMoreGrades ? 'Show Less' : 'Show More'}
-                                </Button>
-                              </TableCell>
-                            </TableRow>
-                          </>
-                        )}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </BaseCard>
+                <GradeTable
+                  title={['Grade', 'Scale']}
+                  data={syllabus.letter_grade_scale.map((row) => [
+                    row.grade,
+                    row.range,
+                  ])}
+                />
               </Grid>
             )}
 

--- a/src/components/common/SyllabusSummary/SyllabusSummary.tsx
+++ b/src/components/common/SyllabusSummary/SyllabusSummary.tsx
@@ -22,15 +22,20 @@ import React, { useEffect, useState } from 'react';
 const MAX_VISIBLE_ROWS = 2;
 
 interface LoadingGradeTableProps {
+  ariaLabel: string;
   title: [string, string];
   dataWidths: [string, string];
 }
 
-function LoadingGradeTable({ title, dataWidths }: LoadingGradeTableProps) {
+function LoadingGradeTable({
+  ariaLabel,
+  title,
+  dataWidths,
+}: LoadingGradeTableProps) {
   return (
     <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
       <TableContainer>
-        <Table size="small" aria-label="grade weighting table">
+        <Table size="small" aria-label={ariaLabel}>
           <colgroup>
             <col className="w-1/2" />
             <col className="w-1/2" />
@@ -82,17 +87,18 @@ function LoadingGradeTable({ title, dataWidths }: LoadingGradeTableProps) {
 }
 
 interface GradeTableProps {
+  ariaLabel: string;
   title: [string, string];
   data: [string, string][];
 }
 
-function GradeTable({ title, data }: GradeTableProps) {
+function GradeTable({ ariaLabel, title, data }: GradeTableProps) {
   const [showMore, setShowMore] = useState(false);
 
   return (
     <BaseCard className="bg-neutral-100 dark:bg-neutral-700">
       <TableContainer>
-        <Table size="small" aria-label="grade weighting table">
+        <Table size="small" aria-label={ariaLabel}>
           <colgroup>
             <col className="w-1/2" />
             <col className="w-1/2" />
@@ -183,6 +189,7 @@ export function LoadingSyllabusSummary({
       {/* Weighting Table */}
       <Grid size={6}>
         <LoadingGradeTable
+          ariaLabel="grade weighting table"
           title={['Weighting', '%']}
           dataWidths={['w-1/2', 'w-1/4']}
         />
@@ -191,6 +198,7 @@ export function LoadingSyllabusSummary({
       {/* Grade Scale Table */}
       <Grid size={6}>
         <LoadingGradeTable
+          ariaLabel="grade scale table"
           title={['Grade', 'Scale']}
           dataWidths={['w-1/4', 'w-1/4']}
         />
@@ -298,6 +306,7 @@ export default function SyllabusSummary({
             syllabus.grade_weights.length > 0 && (
               <Grid size={6}>
                 <GradeTable
+                  ariaLabel="grade weighting table"
                   title={['Weighting', '%']}
                   data={syllabus.grade_weights.map((row) => [
                     row.category,
@@ -312,6 +321,7 @@ export default function SyllabusSummary({
             syllabus.letter_grade_scale.length > 0 && (
               <Grid size={6}>
                 <GradeTable
+                  ariaLabel="grade scale table"
                   title={['Grade', 'Scale']}
                   data={syllabus.letter_grade_scale.map((row) => [
                     row.grade,

--- a/src/components/common/SyllabusSummary/SyllabusSummary.tsx
+++ b/src/components/common/SyllabusSummary/SyllabusSummary.tsx
@@ -3,6 +3,8 @@
 import BaseCard from '@/components/common/BaseCard/BaseCard';
 import { type SearchQuery } from '@/types/SearchQuery';
 import {
+  Button,
+  Collapse,
   Grid,
   Skeleton,
   Table,
@@ -16,6 +18,8 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
+
+const MAX_VISIBLE_ROWS = 2;
 
 export function LoadingSyllabusSummary() {
   return (
@@ -78,6 +82,9 @@ export default function SyllabusSummary({
     }
   }, [open, state, searchQuery, syllabus_uri, syllabus]);
 
+  const [showMoreWeights, setShowMoreWeights] = useState(false);
+  const [showMoreGrades, setShowMoreGrades] = useState(false);
+
   if (state === 'error') {
     return (
       <Grid size={12}>
@@ -88,7 +95,7 @@ export default function SyllabusSummary({
             target="_blank"
             className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
           >
-            View Syllabus
+            View {syllabus_sem} Syllabus
           </Link>
         </div>
       </Grid>
@@ -108,6 +115,10 @@ export default function SyllabusSummary({
                 <BaseCard className="dark:bg-neutral-700">
                   <TableContainer>
                     <Table size="small" aria-label="grade weighting table">
+                      <colgroup>
+                        <col className="w-1/2" />
+                        <col className="w-1/2" />
+                      </colgroup>
                       <TableHead>
                         <TableRow>
                           <TableCell className="font-bold">Weighting</TableCell>
@@ -115,19 +126,83 @@ export default function SyllabusSummary({
                         </TableRow>
                       </TableHead>
                       <TableBody>
-                        {syllabus.grade_weights.map((row, idx) => (
-                          <TableRow
-                            key={idx}
-                            sx={{
-                              '&:last-child td, &:last-child th': { border: 0 },
-                            }}
-                          >
-                            <TableCell component="th" scope="row">
-                              {row.category}
-                            </TableCell>
-                            <TableCell>{row.percentage}</TableCell>
-                          </TableRow>
-                        ))}
+                        {syllabus.grade_weights
+                          .slice(0, MAX_VISIBLE_ROWS)
+                          .map((row, idx) => (
+                            <TableRow
+                              key={idx}
+                              sx={{
+                                '&:last-child td, &:last-child th': {
+                                  border: 0,
+                                },
+                              }}
+                            >
+                              <TableCell component="th" scope="row">
+                                {row.category}
+                              </TableCell>
+                              <TableCell>{row.percentage}</TableCell>
+                            </TableRow>
+                          ))}
+                        {syllabus.grade_weights.length > MAX_VISIBLE_ROWS && (
+                          <>
+                            <TableRow>
+                              <TableCell colSpan={2} className="p-0 border-0">
+                                <Collapse
+                                  in={showMoreWeights}
+                                  timeout="auto"
+                                  unmountOnExit
+                                >
+                                  <Table size="small">
+                                    <colgroup>
+                                      <col className="w-1/2" />
+                                      <col className="w-1/2" />
+                                    </colgroup>
+                                    <TableBody>
+                                      {syllabus.grade_weights
+                                        .slice(MAX_VISIBLE_ROWS)
+                                        .map((row, idx) => (
+                                          <TableRow key={idx}>
+                                            <TableCell
+                                              component="th"
+                                              scope="row"
+                                            >
+                                              {row.category}
+                                            </TableCell>
+                                            <TableCell>
+                                              {row.percentage}
+                                            </TableCell>
+                                          </TableRow>
+                                        ))}
+                                    </TableBody>
+                                  </Table>
+                                </Collapse>
+                              </TableCell>
+                            </TableRow>
+                            <TableRow
+                              sx={{
+                                '&:last-child td, &:last-child th': {
+                                  border: 0,
+                                },
+                              }}
+                            >
+                              <TableCell
+                                align="center"
+                                className="py-0"
+                                colSpan={2}
+                              >
+                                <Button
+                                  className="normal-case"
+                                  size="small"
+                                  onClick={() =>
+                                    setShowMoreWeights(!showMoreWeights)
+                                  }
+                                >
+                                  {showMoreWeights ? 'Show Less' : 'Show More'}
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          </>
+                        )}
                       </TableBody>
                     </Table>
                   </TableContainer>
@@ -142,6 +217,10 @@ export default function SyllabusSummary({
                 <BaseCard className="dark:bg-neutral-700">
                   <TableContainer>
                     <Table size="small" aria-label="grade scale table">
+                      <colgroup>
+                        <col className="w-1/2" />
+                        <col className="w-1/2" />
+                      </colgroup>
                       <TableHead>
                         <TableRow>
                           <TableCell className="font-bold">Grade</TableCell>
@@ -149,19 +228,82 @@ export default function SyllabusSummary({
                         </TableRow>
                       </TableHead>
                       <TableBody>
-                        {syllabus.letter_grade_scale.map((row, idx) => (
-                          <TableRow
-                            key={idx}
-                            sx={{
-                              '&:last-child td, &:last-child th': { border: 0 },
-                            }}
-                          >
-                            <TableCell component="th" scope="row">
-                              {row.grade}
-                            </TableCell>
-                            <TableCell>{row.range}</TableCell>
-                          </TableRow>
-                        ))}
+                        {syllabus.letter_grade_scale
+                          .slice(0, MAX_VISIBLE_ROWS)
+                          .map((row, idx) => (
+                            <TableRow
+                              key={idx}
+                              sx={{
+                                '&:last-child td, &:last-child th': {
+                                  border: 0,
+                                },
+                              }}
+                            >
+                              <TableCell component="th" scope="row">
+                                {row.grade}
+                              </TableCell>
+                              <TableCell>{row.range}</TableCell>
+                            </TableRow>
+                          ))}
+                        {syllabus.letter_grade_scale.length >
+                          MAX_VISIBLE_ROWS && (
+                          <>
+                            <TableRow>
+                              <TableCell colSpan={2} className="p-0 border-0">
+                                <Collapse
+                                  in={showMoreGrades}
+                                  timeout="auto"
+                                  unmountOnExit
+                                >
+                                  <Table size="small">
+                                    <colgroup>
+                                      <col className="w-1/2" />
+                                      <col className="w-1/2" />
+                                    </colgroup>
+                                    <TableBody>
+                                      {syllabus.letter_grade_scale
+                                        .slice(MAX_VISIBLE_ROWS)
+                                        .map((row, idx) => (
+                                          <TableRow key={idx}>
+                                            <TableCell
+                                              component="th"
+                                              scope="row"
+                                            >
+                                              {row.grade}
+                                            </TableCell>
+                                            <TableCell>{row.range}</TableCell>
+                                          </TableRow>
+                                        ))}
+                                    </TableBody>
+                                  </Table>
+                                </Collapse>
+                              </TableCell>
+                            </TableRow>
+                            <TableRow
+                              sx={{
+                                '&:last-child td, &:last-child th': {
+                                  border: 0,
+                                },
+                              }}
+                            >
+                              <TableCell
+                                align="center"
+                                className="py-0"
+                                colSpan={2}
+                              >
+                                <Button
+                                  className="normal-case"
+                                  size="small"
+                                  onClick={() =>
+                                    setShowMoreGrades(!showMoreGrades)
+                                  }
+                                >
+                                  {showMoreGrades ? 'Show Less' : 'Show More'}
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          </>
+                        )}
                       </TableBody>
                     </Table>
                   </TableContainer>
@@ -193,7 +335,7 @@ export default function SyllabusSummary({
                 target="_blank"
                 className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
               >
-                View Syllabus
+                View {syllabus_sem} Syllabus
               </Link>
             </div>
           </Grid>

--- a/src/components/compare/ComparePage/ComparePage.tsx
+++ b/src/components/compare/ComparePage/ComparePage.tsx
@@ -3,7 +3,7 @@
 import BaseCard from '@/components/common/BaseCard/BaseCard';
 import Compare from '@/components/compare/Compare/Compare';
 import SearchIcon from '@mui/icons-material/Search';
-import { Button, Card, Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 

--- a/src/components/compare/ComparePage/ComparePage.tsx
+++ b/src/components/compare/ComparePage/ComparePage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import BaseCard from '@/components/common/BaseCard/BaseCard';
 import Compare from '@/components/compare/Compare/Compare';
 import SearchIcon from '@mui/icons-material/Search';
 import { Button, Card, Typography } from '@mui/material';
@@ -37,9 +38,9 @@ export default function ComparePage() {
           Go back to search
         </Button>
       </div>
-      <Card className="w-full p-4">
+      <BaseCard className="w-full p-4">
         <Compare isMobile={true} />
-      </Card>
+      </BaseCard>
     </>
   );
 }

--- a/src/components/graph/BarGraph/BarGraph.tsx
+++ b/src/components/graph/BarGraph/BarGraph.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import BaseCard from '@/components/common/BaseCard/BaseCard';
 import { FullscreenCloseIcon } from '@/components/icons/FullscreenCloseIcon/fullscreenCloseIcon';
 import { FullscreenOpenIcon } from '@/components/icons/FullscreenOpenIcon/fullscreenOpenIcon';
 import { compareColors, useRainbowColors } from '@/modules/colors';
@@ -160,7 +161,9 @@ export default function BarGraph(props: Props) {
         className="flex justify-stretch align-stretch"
       >
         <Fade in={fullScreenOpen}>
-          <Card className="p-4 m-12 flex-auto">{graph}</Card>
+          <div className="m-12 flex-auto flex justify-stretch align-stretch">
+            <BaseCard className="p-4 flex-auto">{graph}</BaseCard>
+          </div>
         </Fade>
       </Modal>
     </>

--- a/src/components/graph/BarGraph/BarGraph.tsx
+++ b/src/components/graph/BarGraph/BarGraph.tsx
@@ -4,7 +4,7 @@ import BaseCard from '@/components/common/BaseCard/BaseCard';
 import { FullscreenCloseIcon } from '@/components/icons/FullscreenCloseIcon/fullscreenCloseIcon';
 import { FullscreenOpenIcon } from '@/components/icons/FullscreenOpenIcon/fullscreenOpenIcon';
 import { compareColors, useRainbowColors } from '@/modules/colors';
-import { Card, Fade, Modal, useMediaQuery } from '@mui/material';
+import { Fade, Modal, useMediaQuery } from '@mui/material';
 import type { ApexOptions } from 'apexcharts';
 import dynamic from 'next/dynamic';
 import React, { useState } from 'react';

--- a/src/components/graph/LineGraph/LineGraph.tsx
+++ b/src/components/graph/LineGraph/LineGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FiltersContext } from '@/app/dashboard/FilterContext';
+import BaseCard from '@/components/common/BaseCard/BaseCard';
 import { FullscreenCloseIcon } from '@/components/icons/FullscreenCloseIcon/fullscreenCloseIcon';
 import { FullscreenOpenIcon } from '@/components/icons/FullscreenOpenIcon/fullscreenOpenIcon';
 import { compareColors } from '@/modules/colors';
@@ -372,7 +373,9 @@ export default function LineGraph(props: Props) {
         className="flex justify-stretch align-stretch"
       >
         <Fade in={fullScreenOpen}>
-          <Card className="p-4 m-12 flex-auto">{graph}</Card>
+          <div className="m-12 flex-auto flex justify-stretch align-stretch">
+            <BaseCard className="p-4 flex-auto">{graph}</BaseCard>
+          </div>
         </Fade>
       </Modal>
     </>

--- a/src/components/graph/LineGraph/LineGraph.tsx
+++ b/src/components/graph/LineGraph/LineGraph.tsx
@@ -7,7 +7,7 @@ import { FullscreenOpenIcon } from '@/components/icons/FullscreenOpenIcon/fullsc
 import { compareColors } from '@/modules/colors';
 import type { Grades } from '@/modules/fetchGrades';
 import { displaySemesterName } from '@/modules/semesters';
-import { Card, Fade, Modal, useMediaQuery } from '@mui/material';
+import { Fade, Modal, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import type { ApexOptions } from 'apexcharts';
 import dynamic from 'next/dynamic';

--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -23,11 +23,9 @@ import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import EventIcon from '@mui/icons-material/Event';
 import KeyboardArrowIcon from '@mui/icons-material/KeyboardArrowRight';
 import {
-  Box,
   Checkbox,
   Collapse,
   IconButton,
-  Paper,
   Radio,
   Skeleton,
   Table,

--- a/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
+++ b/src/components/planner/PlannerCoursesTable/PlannerCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import BaseCard from '@/components/common/BaseCard/BaseCard';
 import SingleGradesInfo from '@/components/common/SingleGradesInfo/SingleGradesInfo';
 import SingleProfInfo from '@/components/common/SingleProfInfo/SingleProfInfo';
 import { calculateGrades } from '@/modules/fetchGrades';
@@ -45,10 +46,7 @@ import React, { useState } from 'react';
 
 export function LoadingPlannerCard() {
   return (
-    <Box
-      component={Paper}
-      className="border border-royal dark:border-cornflower-300 rounded-lg"
-    >
+    <BaseCard className="border border-royal dark:border-cornflower-300">
       <div className="p-4 flex items-center gap-4">
         <div className="flex items-center">
           <IconButton aria-label="expand row" size="medium" disabled>
@@ -72,7 +70,7 @@ export function LoadingPlannerCard() {
           <Skeleton />
         </Typography>
       </div>
-    </Box>
+    </BaseCard>
   );
 }
 
@@ -521,11 +519,10 @@ export default function PlannerCard(props: PlannerCardProps) {
 
   const latestSyllabusSection = getLatestSyllabusSection(allMatchedSections);
   return (
-    <Box
-      component={Paper}
+    <BaseCard
       className={
-        'border border-royal dark:border-cornflower-300 rounded-lg' +
-        (props.extraSections ? ' my-4 mx-5 bg-light dark:bg-dark' : '')
+        'border border-royal dark:border-cornflower-300' +
+        (props.extraSections ? ' my-4 mx-5 dark:bg-neutral-700' : '')
       }
     >
       <div
@@ -851,6 +848,6 @@ export default function PlannerCard(props: PlannerCardProps) {
           </div>
         </Collapse>
       }
-    </Box>
+    </BaseCard>
   );
 }

--- a/src/components/search/SearchResultsTable/SearchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/SearchResultsTable.tsx
@@ -2,6 +2,7 @@
 
 import { FiltersContext } from '@/app/dashboard/FilterContext';
 import { useSharedState } from '@/app/SharedStateProvider';
+import BaseCard from '@/components/common/BaseCard/BaseCard';
 import Rating from '@/components/common/Rating/Rating';
 import SingleGradesInfo from '@/components/common/SingleGradesInfo/SingleGradesInfo';
 import SingleProfInfo from '@/components/common/SingleProfInfo/SingleProfInfo';
@@ -44,16 +45,6 @@ const AddToPlanner = dynamic(() => import('./AddToPlanner'), {
   ssr: false,
   loading: () => <Checkbox disabled icon={<BookOutlinedIcon />} />,
 });
-
-// sets the color for the table head cells
-function getCellSx() {
-  return {
-    backgroundColor: 'var(--bg-neutral-200)',
-    '@media (prefers-color-scheme: dark)': {
-      backgroundColor: 'var(--bg-neutral-800)',
-    },
-  };
-}
 
 function LoadingRow() {
   const nameCell = (
@@ -117,15 +108,15 @@ export function LoadingSearchResultsTable() {
         <Table stickyHeader aria-label="collapsible table">
           <TableHead>
             <TableRow>
-              <TableCell className="hidden sm:table-cell" sx={getCellSx()}>
+              <TableCell className="hidden sm:table-cell dark:bg-neutral-800">
                 Actions
               </TableCell>
-              <TableCell sx={getCellSx()}>
+              <TableCell className="dark:bg-neutral-800">
                 <TableSortLabel active direction="asc">
                   Name
                 </TableSortLabel>
               </TableCell>
-              <TableCell align="center" sx={getCellSx()}>
+              <TableCell align="center" className="dark:bg-neutral-800">
                 <Tooltip
                   title="Median Letter Grade Across Course Sections"
                   placement="top"
@@ -135,7 +126,7 @@ export function LoadingSearchResultsTable() {
                   </div>
                 </Tooltip>
               </TableCell>
-              <TableCell align="center" sx={getCellSx()}>
+              <TableCell align="center" className="dark:bg-neutral-800">
                 <Tooltip
                   title="Average Professor Rating from Rate My Professors"
                   placement="top"
@@ -590,89 +581,92 @@ export default function SearchResultsTable({
       <Typography className="leading-tight text-3xl font-bold p-4">
         Search Results
       </Typography>
-      <TableContainer component={Paper}>
-        <Table stickyHeader aria-label="collapsible table">
-          <TableHead>
-            <TableRow>
-              <TableCell className="hidden sm:table-cell" sx={getCellSx()}>
-                Actions
-              </TableCell>
-              <TableCell sx={getCellSx()}>
-                <TableSortLabel
-                  active={orderBy === 'name'}
-                  direction={orderBy === 'name' ? order : 'asc'}
-                  onClick={() => {
-                    handleClick('name');
-                  }}
-                >
-                  Name
-                </TableSortLabel>
-              </TableCell>
-              <TableCell align="center" sx={getCellSx()}>
-                <Tooltip
-                  title="Average Letter Grade Across Course Sections"
-                  placement="top"
-                >
-                  <div>
-                    <TableSortLabel
-                      active={orderBy === 'gpa'}
-                      direction={orderBy === 'gpa' ? order : 'desc'}
-                      onClick={() => {
-                        handleClick('gpa');
-                      }}
-                    >
-                      Grades
-                    </TableSortLabel>
-                  </div>
-                </Tooltip>
-              </TableCell>
-              <TableCell align="center" sx={getCellSx()}>
-                <Tooltip
-                  title="Average Professor Rating from Rate My Professors"
-                  placement="top"
-                >
-                  <div>
-                    <TableSortLabel
-                      active={orderBy === 'rating'}
-                      direction={orderBy === 'rating' ? order : 'desc'}
-                      onClick={() => {
-                        handleClick('rating');
-                      }}
-                    >
-                      Rating
-                    </TableSortLabel>
-                  </div>
-                </Tooltip>
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {/* Included Results */}
-            {sortedResults.map((result, index) => {
-              return (
-                <Row
-                  searchResult={result}
-                  key={searchQueryLabel(result.searchQuery)}
-                  course={result.searchQuery}
-                  inCompare={compare.some((obj) =>
-                    searchQueryEqual(obj.searchQuery, result.searchQuery),
-                  )}
-                  addToCompare={addToCompare}
-                  removeFromCompare={removeFromCompare}
-                  color={compareColorMap[searchQueryLabel(result.searchQuery)]}
-                  showTutorial={index === numSearches}
-                />
-              );
-            })}
-
-            {/* First Divider row */}
-            {sortedSecondaryIncludedResults.length > 0 && (
+      <BaseCard className="overflow-hidden">
+        <TableContainer>
+          <Table stickyHeader aria-label="collapsible table">
+            <TableHead>
               <TableRow>
-                <TableCell colSpan={5} className="p-0">
-                  <div className="flex items-center py-2 my-2">
-                    <Divider className="grow" />
-                    <Typography className="px-4 text-base font-bold text-gray-500 dark:text-gray-300">
-                      {`Teaching  
+                <TableCell className="hidden sm:table-cell dark:bg-neutral-800">
+                  Actions
+                </TableCell>
+                <TableCell className="dark:bg-neutral-800">
+                  <TableSortLabel
+                    active={orderBy === 'name'}
+                    direction={orderBy === 'name' ? order : 'asc'}
+                    onClick={() => {
+                      handleClick('name');
+                    }}
+                  >
+                    Name
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell align="center" className="dark:bg-neutral-800">
+                  <Tooltip
+                    title="Average Letter Grade Across Course Sections"
+                    placement="top"
+                  >
+                    <div>
+                      <TableSortLabel
+                        active={orderBy === 'gpa'}
+                        direction={orderBy === 'gpa' ? order : 'desc'}
+                        onClick={() => {
+                          handleClick('gpa');
+                        }}
+                      >
+                        Grades
+                      </TableSortLabel>
+                    </div>
+                  </Tooltip>
+                </TableCell>
+                <TableCell align="center" className="dark:bg-neutral-800">
+                  <Tooltip
+                    title="Average Professor Rating from Rate My Professors"
+                    placement="top"
+                  >
+                    <div>
+                      <TableSortLabel
+                        active={orderBy === 'rating'}
+                        direction={orderBy === 'rating' ? order : 'desc'}
+                        onClick={() => {
+                          handleClick('rating');
+                        }}
+                      >
+                        Rating
+                      </TableSortLabel>
+                    </div>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {/* Included Results */}
+              {sortedResults.map((result, index) => {
+                return (
+                  <Row
+                    searchResult={result}
+                    key={searchQueryLabel(result.searchQuery)}
+                    course={result.searchQuery}
+                    inCompare={compare.some((obj) =>
+                      searchQueryEqual(obj.searchQuery, result.searchQuery),
+                    )}
+                    addToCompare={addToCompare}
+                    removeFromCompare={removeFromCompare}
+                    color={
+                      compareColorMap[searchQueryLabel(result.searchQuery)]
+                    }
+                    showTutorial={index === numSearches}
+                  />
+                );
+              })}
+
+              {/* First Divider row */}
+              {sortedSecondaryIncludedResults.length > 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} className="p-0">
+                    <div className="flex items-center py-2 my-2">
+                      <Divider className="grow" />
+                      <Typography className="px-4 text-base font-bold text-gray-500 dark:text-gray-300">
+                        {`Teaching  
                         ${
                           effectiveTeachingSemester !== ''
                             ? 'in ' +
@@ -682,73 +676,78 @@ export default function SearchResultsTable({
                               )
                             : 'Next Semester'
                         }, Filters Do Not Match`}
-                    </Typography>
-                    <Divider className="grow" />
-                  </div>
-                </TableCell>
-              </TableRow>
-            )}
+                      </Typography>
+                      <Divider className="grow" />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
 
-            {/* Secondary Included Results (Available but do not match filters) */}
-            {sortedSecondaryIncludedResults.map((result) => {
-              return (
-                <Row
-                  searchResult={result}
-                  key={searchQueryLabel(result.searchQuery)}
-                  course={result.searchQuery}
-                  inCompare={compare.some((obj) =>
-                    searchQueryEqual(obj.searchQuery, result.searchQuery),
-                  )}
-                  addToCompare={addToCompare}
-                  removeFromCompare={removeFromCompare}
-                  color={compareColorMap[searchQueryLabel(result.searchQuery)]}
-                  showTutorial={false}
-                />
-              );
-            })}
+              {/* Secondary Included Results (Available but do not match filters) */}
+              {sortedSecondaryIncludedResults.map((result) => {
+                return (
+                  <Row
+                    searchResult={result}
+                    key={searchQueryLabel(result.searchQuery)}
+                    course={result.searchQuery}
+                    inCompare={compare.some((obj) =>
+                      searchQueryEqual(obj.searchQuery, result.searchQuery),
+                    )}
+                    addToCompare={addToCompare}
+                    removeFromCompare={removeFromCompare}
+                    color={
+                      compareColorMap[searchQueryLabel(result.searchQuery)]
+                    }
+                    showTutorial={false}
+                  />
+                );
+              })}
 
-            {/* Divider row */}
-            {sortedUnIncludedResults.length > 0 && (
-              <TableRow>
-                <TableCell colSpan={5} className="p-0">
-                  <div className="flex items-center py-2 my-2">
-                    <Divider className="grow" />
-                    <Typography className="px-4 text-base font-bold text-gray-500 dark:text-gray-300">
-                      {'Not teaching ' +
-                        (effectiveTeachingSemester !== ''
-                          ? 'in ' +
-                            displaySemesterName(
-                              effectiveTeachingSemester,
-                              false,
-                            )
-                          : 'Next Semester')}
-                    </Typography>
-                    <Divider className="grow" />
-                  </div>
-                </TableCell>
-              </TableRow>
-            )}
+              {/* Divider row */}
+              {sortedUnIncludedResults.length > 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} className="p-0">
+                    <div className="flex items-center py-2 my-2">
+                      <Divider className="grow" />
+                      <Typography className="px-4 text-base font-bold text-gray-500 dark:text-gray-300">
+                        {'Not teaching ' +
+                          (effectiveTeachingSemester !== ''
+                            ? 'in ' +
+                              displaySemesterName(
+                                effectiveTeachingSemester,
+                                false,
+                              )
+                            : 'Next Semester')}
+                      </Typography>
+                      <Divider className="grow" />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
 
-            {/* Unincluded Results (Unavailable courses) */}
-            {sortedUnIncludedResults.map((result) => {
-              return (
-                <Row
-                  searchResult={result}
-                  key={searchQueryLabel(result.searchQuery)}
-                  course={result.searchQuery}
-                  inCompare={compare.some((obj) =>
-                    searchQueryEqual(obj.searchQuery, result.searchQuery),
-                  )}
-                  addToCompare={addToCompare}
-                  removeFromCompare={removeFromCompare}
-                  color={compareColorMap[searchQueryLabel(result.searchQuery)]}
-                  showTutorial={false}
-                />
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
+              {/* Unincluded Results (Unavailable courses) */}
+              {sortedUnIncludedResults.map((result) => {
+                return (
+                  <Row
+                    searchResult={result}
+                    key={searchQueryLabel(result.searchQuery)}
+                    course={result.searchQuery}
+                    inCompare={compare.some((obj) =>
+                      searchQueryEqual(obj.searchQuery, result.searchQuery),
+                    )}
+                    addToCompare={addToCompare}
+                    removeFromCompare={removeFromCompare}
+                    color={
+                      compareColorMap[searchQueryLabel(result.searchQuery)]
+                    }
+                    showTutorial={false}
+                  />
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </BaseCard>
     </>
   );
 }

--- a/src/types/SearchQuery.tsx
+++ b/src/types/SearchQuery.tsx
@@ -114,6 +114,22 @@ export function isCourseQuery(
   return searchQuery.prefix !== undefined && searchQuery.number !== undefined;
 }
 
+export function isComboQuery(
+  searchQuery: SearchQuery,
+): searchQuery is SearchQuery & {
+  prefix: string;
+  number: string;
+  profFirst: string;
+  profLast: string;
+} {
+  return (
+    searchQuery.prefix !== undefined &&
+    searchQuery.number !== undefined &&
+    searchQuery.profFirst !== undefined &&
+    searchQuery.profLast !== undefined
+  );
+}
+
 export function removeSection(
   searchQuery: SearchQuery | SearchQueryMultiSection,
 ): SearchQuery {


### PR DESCRIPTION
Separated the the RMP and syllabus summary features in card dropdowns so now you can see the syllabus summary when the professor does not have any RMP. I also updated the style to use dense MUI tables so it's more recognizable as multiple tables.

In the process, I needed the BaseCard component added to all the projects in the #558 set of issues and realized it should have been added in #613. I missed that in the review so added it here. This matches card colors, rounded corners, and shadows with the rest of the Nebula projects. For the most part the cards just look a tad lighter, easy to see the difference by tabbing between https://dev.trends.utdnebula.com/dashboard?searchTerms=John+Cole&availability=26F and https://utd-trends-git-607-separate-rmp-and-syllabus-utdnebula.vercel.app/dashboard?searchTerms=John+Cole&availability=26F.

Before:
<img width="1123" height="1112" alt="image" src="https://github.com/user-attachments/assets/6c39abe3-0c5d-4ed8-bd90-bfe811adc45a" />

After:
<img width="1116" height="854" alt="image" src="https://github.com/user-attachments/assets/2f7e8485-d731-4ea5-aebe-a772bb6546bb" />
(expanded)
<img width="1119" height="1101" alt="image" src="https://github.com/user-attachments/assets/538e5f81-edb8-453f-abc2-adecf4cd1b47" />
