### PR TITLE
fix: handle localStorage errors

### DIFF
--- a/__tests__/localStorage.test.tsx
+++ b/__tests__/localStorage.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  getRecentSearches,
+  updateRecentSearches,
+} from '@/components/search/SearchBar/SearchBar';
+import usePersistantState from '@/modules/usePersistantState';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { mockSearchQuery } from '../mocks/SearchQuery.mocks';
+
+describe('localStorage errors', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('uses the missing-value fallback when persistent state cannot be read', async () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    const { result } = renderHook(() =>
+      usePersistantState('test-key', 'initial', true, 'default'),
+    );
+
+    await waitFor(() => expect(result.current[0]).toBe('default'));
+  });
+
+  it('updates persistent state in memory when storage cannot be written', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    const { result } = renderHook(() =>
+      usePersistantState('test-key', 'initial'),
+    );
+
+    act(() => result.current[1]('updated'));
+
+    expect(result.current[0]).toBe('updated');
+  });
+
+  it('returns no recent searches when storage cannot be read', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    expect(getRecentSearches()).toEqual([]);
+  });
+
+  it('does not throw when recent searches cannot be written', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    expect(() => updateRecentSearches([mockSearchQuery])).not.toThrow();
+  });
+});

--- a/src/components/search/SearchBar/SearchBar.tsx
+++ b/src/components/search/SearchBar/SearchBar.tsx
@@ -70,7 +70,12 @@ export function LoadingSearchBar(props: LoadingSearchBarProps) {
 }
 
 export function getRecentSearches() {
-  const searchesText = window.localStorage.getItem('UTDTrendsRecent');
+  let searchesText: string | null;
+  try {
+    searchesText = window.localStorage.getItem('UTDTrendsRecent');
+  } catch {
+    return [];
+  }
   let recSearches: SearchQueryWithTitle[] = [];
   if (searchesText != null) {
     recSearches = JSON.parse(searchesText);
@@ -86,10 +91,15 @@ export function updateRecentSearches(newValue: SearchQueryWithTitle[]) {
   const dedupArray = removeDuplicates(concatArray)
     .slice(0, 3)
     .map((el) => ({ ...el, isRecent: true }));
-  window.localStorage.setItem(
-    'UTDTrendsRecent',
-    JSON.stringify(dedupArray), // ensure no title/subtitle/isRecent fields are stored
-  );
+  const storedSearches = JSON.stringify(dedupArray);
+  try {
+    window.localStorage.setItem(
+      'UTDTrendsRecent',
+      storedSearches, // ensure no title/subtitle/isRecent fields are stored
+    );
+  } catch {
+    return;
+  }
 }
 
 type SearchQueryWithTitle = SearchQuery & {

--- a/src/modules/usePersistantState.tsx
+++ b/src/modules/usePersistantState.tsx
@@ -12,7 +12,12 @@ export default function usePersistantState<T>(
   const defaultValueRef = useRef(defaultValue);
   useEffect(() => {
     function setFromStorage() {
-      const value = localStorage.getItem(key);
+      let value: string | null;
+      try {
+        value = localStorage.getItem(key);
+      } catch {
+        value = null;
+      }
       if (!value) {
         if (useDefaultValue) {
           internalSetState(defaultValueRef.current);
@@ -45,7 +50,12 @@ export default function usePersistantState<T>(
       const newValue =
         typeof value === 'function' ? (value as (prev: T) => T)(prev) : value;
 
-      localStorage.setItem(key, JSON.stringify(newValue));
+      const serializedValue = JSON.stringify(newValue);
+      try {
+        localStorage.setItem(key, serializedValue);
+      } catch {
+        return newValue;
+      }
       return newValue;
     });
   };


### PR DESCRIPTION
## Overview


Guard the app's localStorage reads and writes so browsers that block storage do not break persistent state or recent searches.

## What Changed

- Treat blocked reads as missing storage.
- Keep in-memory state updates when persistence fails.
- Return an empty recent-search list or skip the write when storage is unavailable.
- Add regression tests for all four production storage calls.

## Other Notes

`npm run lint:check`, `npm run format:check`, `npm run type:check`, and all 6 Jest tests pass.