### PR TITLE
Upgrade Gemini models

### DIFF
--- a/src/app/api/rmpSummary/route.ts
+++ b/src/app/api/rmpSummary/route.ts
@@ -118,7 +118,7 @@ Summary requirements:
     },
   });
   const response = await geminiClient.models.generateContent({
-    model: 'gemini-2.5-flash-lite',
+    model: 'gemini-3.1-flash-lite',
     contents: prompt,
   });
 

--- a/src/app/api/syllabusSummary/route.ts
+++ b/src/app/api/syllabusSummary/route.ts
@@ -138,7 +138,7 @@ export async function GET(request: Request) {
     },
   });
   const response = await geminiClient.models.generateContent({
-    model: 'gemini-2.5-flash-lite',
+    model: 'gemini-3.1-flash-lite',
     config: {
       responseMimeType: 'application/json',
       responseSchema: syllabusResponseSchema,


### PR DESCRIPTION
Got an email Gemini 2.5 models are being discontinued. This just means stuff could change after October 20th but most importantly prices will "increase significantly" after January 28th. It would still be a good goal to have these changes in `main` by October 20th. For Trends maybe it could be worth waiting until after the start of the school year but it's probably also fine.

This PR is untested since I assume the model names don't really change. The price changes for merging this PR is below:

| Price (/1M tokens) <= 200K input tokens | Input| Output |
| - | - | - |
| gemini-2.5-flash-lite | $0.10 | $0.40 |
| gemini-3.1-flash-lite | $0.25 | $1.5 |

Related PRs:
- https://github.com/UTDNebula/utd-clubs/pull/715
- https://github.com/UTDNebula/api-tools/pull/180

@AbhiramTadepalli FYI

<details>
<summary>Email contents that I asked an AI to convert to markdown</summary>

You’re receiving this communication because one or more of your **Google Cloud** projects use **Gemini Enterprise Agent Platform** (formerly known as **Vertex AI**) endpoints.

As we continue to advance our Gemini model capabilities, we will discontinue the following Gemini Enterprise Agent Platform endpoints on **October 20, 2026**, per our [model lifecycle documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versioning).

* **Gemini 2.5 Flash Lite**
* **Gemini 2.5 Flash**
* **Gemini 2.5 Pro**

This notice does **not** apply to Data Residency Zone (in-country) deployments of Gemini 2.5 models in South Korea, Brazil, and France. These regions have separate migration guidance, which you will receive in a separate, dedicated notice.

**Note:** This update applies only to Gemini Enterprise Agent Platform. If you have projects using **[Gemini on AI Studio](https://aistudio.google.com/)**, different discontinuation dates may apply. You can find more information in the [Gemini deprecations](https://www.google.com/search?q=https://ai.google.dev/gemini-api/docs/models/legacy) documentation.

We understand that making this change may require some planning and have provided additional information below to help you with the transition.

## What you need to know

**Key changes starting October 20, 2026:**

* We will discontinue the Gemini 2.5 model versions on Gemini Enterprise Agent Platform mentioned above.
* Gemini 2.5 models will enter Extended Lifecycle Access (ELA) and be subject to the ELA terms.

**ELA:**

To support you in your migration to the recommended upgrade models listed above, we will launch ELA starting **October 20, 2026** with no action needed from you. You will be able to continue calling the model with the same General Availability (GA) commercial terms, but the above models will be considered deprecated.

**Pricing during ELA:**

* **October 20, 2026 – January 28, 2027:** Same pricing as 2.5 models today
* **After January 28, 2027:** Pricing will significantly increase (details to follow soon) and availability in regions may also change. We recommend upgrading to the latest models before this time.

**Potential impact:**

* **Service change:** Starting **October 20, 2026**, Gemini 2.5 models will be in ELA and subject to the terms listed above
* **Pricing and billing:** Costs may change with this model upgrade. You can review the [pricing for Gemini models page](https://cloud.google.com/vertex-ai/generative-ai/pricing) for more details

---

## What you need to do

**Action required:**

Upgrade to the latest models:

1. **Test workflows:** Validate your existing workflows to ensure they are compatible with the recommended GA models listed below. We encourage you to test multiple migration paths.
2. **Migrate:** Transition your workflows to the following recommended GA migration targets:

| Current Preview Model | Recommended GA Migration Target |
| --- | --- |
| Gemini 2.5 Flash Lite | Gemini 3.1 Flash Lite / Gemma 4 |
| Gemini 2.5 Flash | Gemini 3.5 Flash Lite / 3.1 Flash Lite / 3.5 Flash |
| Gemini 2.5 Pro | Gemini 3.5 Flash / 3.6 Flash |

3. **Implement thought signature circulation:** To ensure the Gemini 3 models maintain their reasoning capabilities, you must capture the thought signatures from each response and include them in your follow-up request to the model, exactly as received. Refer to the [Thought signatures](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/thought-signatures) guide for implementation details.

**Recommended for review:**

* **Review prices:** Evaluate the [Agent Platform Pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) documentation for Gemini 3 models as costs will change. To optimize costs, many use cases can achieve a better balance by migrating to a lighter Gemini 3 tier (for example, moving from a Flash workload to 3.1 / 3.5 Flash Lite, or a Pro workload to 3.5 Flash).
* **Update Provisioned Throughput (PT):** If you’ve purchased PT for these models, you must migrate to a new model. To migrate using the self-service console, follow the instructions in the [Change a standard Provisioned Throughput order guidelines](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput).

**Timelines:**

* **October 20, 2026 (Deprecation):** Models enter ELA automatically. Your current pricing remains unchanged through January 28, 2027.
* **January 28, 2027 (Significant Price Hike):** ELA standard pricing ends and costs increase significantly. Complete all migrations before this date to optimize costs and avoid disruption.

---

### Your affected projects are listed below:

**Gemini 2.5 Flash Lite**

* `trends-478017`
* `jupiter-459023`

**Gemini 2.5 Flash**

* `api-tools-451421`
* `trends-478017`
* `jupiter-459023`

**Gemini 2.5 Pro**

* `api-tools-451421`

---

## We’re here to help

We’ve provided the following resources to help you with this transition:

* **Model migration:** Step-by-step instructions to the [latest Gemini models](https://cloud.google.com/vertex-ai/generative-ai/docs/migrate/migrate-model-versions)
* **Migration guide and docs:** Deep dive into the technical details via our [product documentation](https://cloud.google.com/vertex-ai/generative-ai/docs) and [migration guide](https://cloud.google.com/vertex-ai/generative-ai/docs/migrate/migrate-model-versions)
* **Regional availability:** Refer to our [Deployments and endpoints](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations) documentation to check Gemini 3.1 and 3.5 availability in your region

If you have any questions or require assistance, please contact [Google Cloud Support](https://cloud.google.com/support).

Thanks for choosing Gemini Enterprise Agent Platform.
</details>