### PR TITLE
add a catch to the wake-up dummy autocomplete fetch

### DIFF
--- a/src/components/search/SearchBar/SearchBar.tsx
+++ b/src/components/search/SearchBar/SearchBar.tsx
@@ -432,7 +432,7 @@ export default function SearchBar(props: Props) {
   }
 
   useEffect(() => {
-    void fetch('/api/autocomplete?input=someSearchTerm');
+    void fetch('/api/autocomplete?input=someSearchTerm').catch(() => {});
   }, []);
 
   const [highlightedOption, setHighlightedOption] = useState<boolean>(false);


### PR DESCRIPTION


## Overview
Fixes #632 to resolve Sentry issue [TRENDS-17](https://utdnebula.sentry.io/issues/6748748656/?referrer=github_integration)

## What Changed
The `fetch('/api/autocomplete?input=someSearchTerm')` is used to wake up the autocomplete endpoint. It needs a `catch()` to prevent a network error from crashing app (in IOS Safari among other environments).