### PR TITLE
fix(course-overview): preserve periodless descriptions

### DIFF
--- a/__tests__/CourseOverview.test.ts
+++ b/__tests__/CourseOverview.test.ts
@@ -1,0 +1,45 @@
+import { parseDescription } from '@/components/overview/CourseOverview/CourseOverview';
+import type { Course } from '@/modules/fetchCourse';
+
+function createCourse(description: string): Course {
+  return {
+    course_number: '1301',
+    credit_hours: 3,
+    description,
+    title: 'Introduction to Literature',
+  } as Course;
+}
+
+describe('parseDescription', () => {
+  it('preserves a description without a terminal period', () => {
+    const description =
+      'LIT 1301 - Introduction to Literature (3 semester credit hours) Introduction to literary analysis and interpretation based on readings from a global range of authors (3-0) S';
+
+    expect(parseDescription(createCourse(description))).toMatchObject({
+      formattedDescription:
+        ' Introduction to literary analysis and interpretation based on readings from a global range of authors (3-0) S',
+      offeringFrequency: 'Each semester',
+    });
+  });
+
+  it('preserves internal periods when there is no terminal period', () => {
+    const description =
+      'LIT 1301 - Introduction to Literature (3 semester credit hours) Introduction to U.S. literature from a global range of authors (3-0) S';
+
+    expect(parseDescription(createCourse(description))).toMatchObject({
+      formattedDescription:
+        ' Introduction to U.S. literature from a global range of authors (3-0) S',
+      offeringFrequency: 'Each semester',
+    });
+  });
+
+  it('continues to trim metadata after a terminal period', () => {
+    const description =
+      'LIT 1301 - Introduction to Literature (3 semester credit hours) Introduction to literary analysis. (3-0) S';
+
+    expect(parseDescription(createCourse(description))).toMatchObject({
+      formattedDescription: ' Introduction to literary analysis.',
+      offeringFrequency: 'Each semester',
+    });
+  });
+});

--- a/src/components/overview/CourseOverview/CourseOverview.tsx
+++ b/src/components/overview/CourseOverview/CourseOverview.tsx
@@ -47,7 +47,7 @@ export function LoadingCourseOverview() {
   );
 }
 
-function parseDescription(course: Course): {
+export function parseDescription(course: Course): {
   formattedDescription: string;
   requisites: string[];
   sameAsText: string;
@@ -212,11 +212,16 @@ function parseDescription(course: Course): {
       0,
       requisites[lastRequisite].lastIndexOf('.') + 1,
     );
-  } else
-    formattedDescription = formattedDescription.substring(
-      0,
-      formattedDescription.lastIndexOf('.') + 1,
+  } else {
+    const lastPeriod = formattedDescription.lastIndexOf('.');
+    const textAfterLastPeriod = formattedDescription.substring(lastPeriod + 1);
+    const hasOnlyCourseMetadata = /^\s+\([\d-]+\)\s+[SYTRPFU]\s*$/.test(
+      textAfterLastPeriod,
     );
+    if (lastPeriod != -1 && hasOnlyCourseMetadata) {
+      formattedDescription = formattedDescription.substring(0, lastPeriod + 1);
+    }
+  }
 
   return {
     formattedDescription,


### PR DESCRIPTION
## Overview

Course descriptions without a terminal period no longer collapse to an empty string. The parser now removes trailing contact-hours/frequency metadata only when it follows an actual terminal period; otherwise it preserves the complete description, including internal periods such as `U.S.`.

## What Changed

- updated `parseDescription` to recognize the catalog metadata suffix before trimming at the last period
- exported the parser for focused unit coverage
- added cases for the reported period-less LIT 1301 description, a period-less description with an internal period, and the existing terminal-period behavior

## Verification

- `npm test -- --runInBand` — 2 suites, 5 tests passed
- `npm run lint:check`
- `npm run format:check`
- `npm run type:check`

All commands ran with Node 22 as required by the repository.
