### PR TITLE
fix: preserve A+ median grades

### DIFF
--- a/__tests__/fetchGrades.test.ts
+++ b/__tests__/fetchGrades.test.ts
@@ -1,0 +1,39 @@
+import { calculateGrades, type GradesData } from '@/modules/fetchGrades';
+
+function gradesWithDistribution(distribution: number[]): GradesData {
+  return [
+    {
+      _id: '26F',
+      data: [{ type: 'LEC', grade_distribution: distribution }],
+    },
+  ];
+}
+
+describe('calculateGrades median', () => {
+  it('preserves A+ when it accounts for half of the letter grades', () => {
+    const result = calculateGrades(gradesWithDistribution([5, 5]));
+
+    expect(result.gpa).toBe(4);
+    expect(result.median_letter_grade).toBe('A+');
+  });
+
+  it('reports A when fewer than half of the letter grades are A+', () => {
+    const result = calculateGrades(gradesWithDistribution([4, 6]));
+
+    expect(result.gpa).toBe(4);
+    expect(result.median_letter_grade).toBe('A');
+  });
+
+  it('uses the middle grade for an odd number of letter grades', () => {
+    const result = calculateGrades(gradesWithDistribution([2, 3]));
+
+    expect(result.median_letter_grade).toBe('A');
+  });
+
+  it('handles a single letter grade', () => {
+    const result = calculateGrades(gradesWithDistribution([1]));
+
+    expect(result.gpa).toBe(4);
+    expect(result.median_letter_grade).toBe('A+');
+  });
+});

--- a/src/components/common/SingleGradesInfo/SingleGradesInfo.tsx
+++ b/src/components/common/SingleGradesInfo/SingleGradesInfo.tsx
@@ -2,7 +2,6 @@ import BarGraph from '@/components/graph/BarGraph/BarGraph';
 import LineGraph from '@/components/graph/LineGraph/LineGraph';
 import GraphToggle from '@/components/navigation/GraphToggle/GraphToggle';
 import type { GradesData, GradesSummary } from '@/modules/fetchGrades';
-import gpaToLetterGrade from '@/modules/gpaToLetterGrade';
 import { searchQueryLabel, type SearchQuery } from '@/types/SearchQuery';
 import { Skeleton } from '@mui/material';
 import React from 'react';
@@ -116,7 +115,7 @@ export default function SingleGradesInfo({
           <b>
             {filteredGrades.gpa === -1
               ? 'None'
-              : gpaToLetterGrade(filteredGrades.gpa)}
+              : filteredGrades.median_letter_grade}
           </b>
         </p>
         <p>

--- a/src/components/search/SearchResultsTable/SearchResultsTable.tsx
+++ b/src/components/search/SearchResultsTable/SearchResultsTable.tsx
@@ -9,7 +9,6 @@ import SingleProfInfo from '@/components/common/SingleProfInfo/SingleProfInfo';
 import TableSortLabel from '@/components/common/TableSortLabel/TableSortLabel';
 import { gpaToColor, useRainbowColors } from '@/modules/colors';
 import { calculateGrades } from '@/modules/fetchGrades';
-import gpaToLetterGrade from '@/modules/gpaToLetterGrade';
 import { getLatestSyllabusSection } from '@/modules/sections';
 import { displaySemesterName } from '@/modules/semesters';
 import {
@@ -337,7 +336,7 @@ function Row({
                   ),
                 }}
               >
-                {gpaToLetterGrade(filteredGrades.gpa)}
+                {filteredGrades.median_letter_grade}
               </Typography>
             </Tooltip>
           )) ||

--- a/src/modules/fetchGrades.ts
+++ b/src/modules/fetchGrades.ts
@@ -3,6 +3,7 @@ import { type SearchQuery } from '@/types/SearchQuery';
 export type GradesSummary = {
   mean_gpa: number;
   gpa: number;
+  median_letter_grade: string | null;
   total: number;
   grade_distribution: number[];
 };
@@ -54,6 +55,21 @@ export function calculateGrades(
   const GPALookup = [
     4, 4, 3.67, 3.33, 3, 2.67, 2.33, 2, 1.67, 1.33, 1, 0.67, 0,
   ];
+  const letterGrades = [
+    'A+',
+    'A',
+    'A-',
+    'B+',
+    'B',
+    'B-',
+    'C+',
+    'C',
+    'C-',
+    'D+',
+    'D',
+    'D-',
+    'F',
+  ];
 
   // exclude all entries after F from total
   const totalLetterGrades =
@@ -74,19 +90,24 @@ export function calculateGrades(
   }
 
   let median_gpa = -1;
-  let medianIndex = -1;
+  let median_letter_grade: string | null = null;
   if (totalLetterGrades != 0) {
-    let i = Math.floor(totalLetterGrades / 2);
-    while (i > 0) {
-      medianIndex++;
-      i -= grade_distribution[medianIndex];
+    const medianPosition = Math.ceil(totalLetterGrades / 2);
+    let cumulativeGrades = 0;
+    for (let index = 0; index < GPALookup.length; index++) {
+      cumulativeGrades += grade_distribution[index];
+      if (cumulativeGrades >= medianPosition) {
+        median_gpa = GPALookup[index];
+        median_letter_grade = letterGrades[index];
+        break;
+      }
     }
-    median_gpa = GPALookup[medianIndex];
   }
 
   return {
     mean_gpa: mean_gpa,
     gpa: median_gpa,
+    median_letter_grade,
     total: total,
     grade_distribution: grade_distribution,
   };


### PR DESCRIPTION
## Overview

Resolves #637

Preserve the categorical median grade instead of converting A+ and A to the same numeric GPA and then losing the distinction when rendering the result.

## What Changed

- calculate the median from the cumulative grade distribution using the correct middle position
- return the corresponding categorical median alongside the numeric GPA used for sorting and colors
- display that categorical value in search results and grade summaries
- cover the 50% A+ boundary, a below-50% distribution, odd totals, and a single-grade edge case

## Verification

- `npm run format:check`
- `npm run lint:check`
- `npm test -- --runInBand` — 2 suites and 6 tests passed
- `SKIP_ENV_VALIDATION=1 npm run type:check`

## AI Disclosure

Codex was used to inspect the issue and code path, implement the fix and tests, and run the verification commands.